### PR TITLE
[feat] : 공통 헤더 구현

### DIFF
--- a/public/icon/back.svg
+++ b/public/icon/back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M16 4L8 12L16 20" stroke="#1C1C22" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icon/close.svg
+++ b/public/icon/close.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="23" height="24" viewBox="0 0 23 24" fill="none">
+  <path d="M5.65683 6.34277L16.9705 17.6565" stroke="#1C1C22" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16.9706 6.34277L5.65684 17.6565" stroke="#1C1C22" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,16 +1,5 @@
-import BackHeader from "@/shared/ui/BackHeader";
-import CloseHeader from "@/shared/ui/CloseHeader";
-import PlainHeader from "@/shared/ui/PlainHeader";
-
 const DetailPage = () => {
-  return (
-    <div>
-      디테일
-      <PlainHeader title="멤버 추가" url="/" />
-      <BackHeader />
-      <CloseHeader />
-    </div>
-  );
+  return <div>디테일</div>;
 };
 
 export default DetailPage;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,5 +1,16 @@
+import BackHeader from "@/shared/ui/BackHeader";
+import CloseHeader from "@/shared/ui/CloseHeader";
+import PlainHeader from "@/shared/ui/PlainHeader";
+
 const DetailPage = () => {
-  return <div>디테일</div>;
+  return (
+    <div>
+      디테일
+      <PlainHeader title="멤버 추가" url="/" />
+      <BackHeader />
+      <CloseHeader />
+    </div>
+  );
 };
 
 export default DetailPage;

--- a/src/shared/ui/BackHeader.tsx
+++ b/src/shared/ui/BackHeader.tsx
@@ -5,13 +5,12 @@ const BackHeader = () => {
 
   return (
     <header className="w-full px-5 py-3">
-      <img
-        src="/icon/back.svg"
-        alt="back"
+      <button
         onClick={() => {
           navigate(-1);
-        }}
-      />
+        }}>
+        <img src="/icon/back.svg" alt="back" />
+      </button>
     </header>
   );
 };

--- a/src/shared/ui/BackHeader.tsx
+++ b/src/shared/ui/BackHeader.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+
+const BackHeader = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="w-full px-5 py-3">
+      <img
+        src="/icon/back.svg"
+        alt="back"
+        onClick={() => {
+          navigate(-1);
+        }}
+      />
+    </div>
+  );
+};
+
+export default BackHeader;

--- a/src/shared/ui/BackHeader.tsx
+++ b/src/shared/ui/BackHeader.tsx
@@ -1,13 +1,17 @@
 import { useNavigate } from "react-router-dom";
 
-const BackHeader = () => {
+interface BackHeaderProps {
+  url: string;
+}
+
+const BackHeader = ({ url }: BackHeaderProps) => {
   const navigate = useNavigate();
 
   return (
     <header className="w-full px-5 py-3">
       <button
         onClick={() => {
-          navigate(-1);
+          navigate(url);
         }}>
         <img src="/icon/back.svg" alt="back" />
       </button>

--- a/src/shared/ui/CloseHeader.tsx
+++ b/src/shared/ui/CloseHeader.tsx
@@ -5,13 +5,12 @@ const CloseHeader = () => {
 
   return (
     <header className="w-full px-5 py-3 flex justify-end">
-      <img
-        src="/icon/close.svg"
-        alt="close"
+      <button
         onClick={() => {
           navigate(-1);
-        }}
-      />
+        }}>
+        <img src="/icon/close.svg" alt="close" />
+      </button>
     </header>
   );
 };

--- a/src/shared/ui/CloseHeader.tsx
+++ b/src/shared/ui/CloseHeader.tsx
@@ -1,13 +1,13 @@
 import { useNavigate } from "react-router-dom";
 
-const BackHeader = () => {
+const CloseHeader = () => {
   const navigate = useNavigate();
 
   return (
-    <header className="w-full px-5 py-3">
+    <header className="w-full px-5 py-3 flex justify-end">
       <img
-        src="/icon/back.svg"
-        alt="back"
+        src="/icon/close.svg"
+        alt="close"
         onClick={() => {
           navigate(-1);
         }}
@@ -16,4 +16,4 @@ const BackHeader = () => {
   );
 };
 
-export default BackHeader;
+export default CloseHeader;

--- a/src/shared/ui/CloseHeader.tsx
+++ b/src/shared/ui/CloseHeader.tsx
@@ -1,13 +1,17 @@
 import { useNavigate } from "react-router-dom";
 
-const CloseHeader = () => {
+interface CloseHeaderProps {
+  url: string;
+}
+
+const CloseHeader = ({ url }: CloseHeaderProps) => {
   const navigate = useNavigate();
 
   return (
     <header className="w-full px-5 py-3 flex justify-end">
       <button
         onClick={() => {
-          navigate(-1);
+          navigate(url);
         }}>
         <img src="/icon/close.svg" alt="close" />
       </button>

--- a/src/shared/ui/PlainHeader.tsx
+++ b/src/shared/ui/PlainHeader.tsx
@@ -2,20 +2,20 @@ import { useNavigate } from "react-router-dom";
 
 interface PlainTextProps {
   title: string;
+  url: string;
 }
 
-const PlainHeader = ({ title }: PlainTextProps) => {
+const PlainHeader = ({ title, url }: PlainTextProps) => {
   const navigate = useNavigate();
 
   return (
     <header className="relative flex w-full px-5 py-3 items-center">
-      <img
-        src="/icon/back.svg"
-        alt="back"
+      <button
         onClick={() => {
-          navigate(-1);
-        }}
-      />
+          navigate(url);
+        }}>
+        <img src="/icon/back.svg" alt="back" />
+      </button>
       <span className="absolute top-3 left-1/2 -translate-x-1/2 text-md font-semibold">{title}</span>
     </header>
   );

--- a/src/shared/ui/PlainHeader.tsx
+++ b/src/shared/ui/PlainHeader.tsx
@@ -1,0 +1,25 @@
+import { useNavigate } from "react-router-dom";
+
+interface PlainTextProps {
+  url: string;
+  title: string;
+}
+
+const PlainHeader = ({ url, title }: PlainTextProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <header className="relative flex w-full px-5 py-3 items-center">
+      <img
+        src="/icon/back.svg"
+        alt="back"
+        onClick={() => {
+          navigate(url);
+        }}
+      />
+      <span className="absolute top-3 left-1/2 -translate-x-1/2 text-md font-semibold">{title}</span>
+    </header>
+  );
+};
+
+export default PlainHeader;

--- a/src/shared/ui/PlainHeader.tsx
+++ b/src/shared/ui/PlainHeader.tsx
@@ -1,11 +1,10 @@
 import { useNavigate } from "react-router-dom";
 
 interface PlainTextProps {
-  url: string;
   title: string;
 }
 
-const PlainHeader = ({ url, title }: PlainTextProps) => {
+const PlainHeader = ({ title }: PlainTextProps) => {
   const navigate = useNavigate();
 
   return (
@@ -14,7 +13,7 @@ const PlainHeader = ({ url, title }: PlainTextProps) => {
         src="/icon/back.svg"
         alt="back"
         onClick={() => {
-          navigate(url);
+          navigate(-1);
         }}
       />
       <span className="absolute top-3 left-1/2 -translate-x-1/2 text-md font-semibold">{title}</span>

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./PlainHeader";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./Button";
 export * from "./PlainHeader";
+export * from "./BackHeader";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,3 +1,4 @@
 export * from "./Button";
 export * from "./PlainHeader";
 export * from "./BackHeader";
+export * from "./CloseHeader";


### PR DESCRIPTION
# 🛠 구현 사항

- plainHeader (텍스트를 가진 기본 헤더)
- backHeader (이전 버튼만을 가진 헤더)
- closeHeader (닫기 버튼만을 가진 헤더)

# ❓ 질문

- X

# 📸 화면 캡처
![image](https://github.com/user-attachments/assets/e7251e39-a0c7-4928-ad6a-31d19d299138)

# 💬 리뷰 요구사항
- 아래는 사용 예시입니다!
```
      <PlainHeader title="멤버 추가" />
      <BackHeader />
      <CloseHeader />
```