### PR TITLE
[fix] : 스크롤과 드래그 이벤트 분리

### DIFF
--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -14,7 +14,7 @@ export const BottomSheetContent = () => {
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto mx-5 pb-[80px] scrollbar-hidden">
+      <div className="flex-1 min-h-0 overflow-y-auto mx-5 pb-[80px] scrollbar-hidden" data-scrollable="true">
         {users.map(user => (
           <UserCard key={user.id} name={user.name} startStation={user.startStation} totalTime={user.totalTime} />
         ))}

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -5,7 +5,7 @@ const MapViewPage = () => {
 
   return (
     <div>
-      <div className="px-5 min-h-[100dvh]">
+      <div className="px-5">
         <MapHeader />
       </div>
       <KakaoMapView />

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -1,11 +1,11 @@
 import { AddMemberBottomSheet, KakaoMapView, MapBottomSheet, MapHeader } from "@/features/mapView/ui";
 
 const MapViewPage = () => {
-  const memberCount = 2;
+  const memberCount = 2; // 임시 인원 설정
 
   return (
     <div>
-      <div className="px-5">
+      <div className="px-5 min-h-[100dvh]">
         <MapHeader />
       </div>
       <KakaoMapView />

--- a/src/shared/hooks/useBottomSheetDrag.ts
+++ b/src/shared/hooks/useBottomSheetDrag.ts
@@ -1,41 +1,60 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from "react";
 
 interface UseBottomSheetDragProps {
   minHeightVh: number;
   maxHeightVh?: number;
 }
 
-export const useBottomSheetDrag = ({ 
+export const useBottomSheetDrag = ({
   minHeightVh = 25, // 기본값 25vh
-  maxHeightVh = 80 // 기본값 80vh
+  maxHeightVh = 80, // 기본값 80vh
 }: UseBottomSheetDragProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [startY, setStartY] = useState(0);
   
-  // vh를 픽셀로 변환
-  const vhToPixels = (vh: number) => (window.innerHeight * vh) / 100;
-  const [currentHeight, setCurrentHeight] = useState(vhToPixels(minHeightVh));
+  // vh를 픽셀로 변환하는 함수를 메모이제이션
+  const vhToPixels = useCallback((vh: number) => (window.innerHeight * vh) / 100, []);
+  const [currentHeight, setCurrentHeight] = useState(() => vhToPixels(minHeightVh));
+
+  // 스크롤 가능한 영역을 ref로 저장
+  const scrollableRef = useRef<HTMLElement | null>(null);
+  // 최소/최대 높이를 픽셀로 변환한 값을 캐시
+  const heightLimitsRef = useRef({
+    min: vhToPixels(minHeightVh),
+    max: vhToPixels(maxHeightVh)
+  });
+
+  // 컴포넌트 마운트 시 한 번만 스크롤 가능한 영역을 찾음
+  useEffect(() => {
+    scrollableRef.current = document.querySelector("[data-scrollable]");
+  }, []);
 
   const handleDragStart = useCallback((event: React.TouchEvent | React.MouseEvent) => {
-    const clientY = 'touches' in event ? event.touches[0].clientY : event.clientY;
+    const clientY = "touches" in event ? event.touches[0].clientY : event.clientY;
+
+    // ref로 저장된 스크롤 가능한 영역의 위치 확인
+    if (scrollableRef.current && scrollableRef.current.scrollTop > 0) {
+      return;
+    }
+
     setIsDragging(true);
     setStartY(clientY);
   }, []);
 
-  const handleDragMove = useCallback((event: TouchEvent | MouseEvent) => {
-    if (!isDragging) return;
+  const handleDragMove = useCallback(
+    (event: TouchEvent | MouseEvent) => {
+      if (!isDragging) return;
 
-    const clientY = 'touches' in event ? (event as TouchEvent).touches[0].clientY : (event as MouseEvent).clientY;
-    const delta = startY - clientY;
-    const newHeight = currentHeight + delta;
+      const clientY = "touches" in event ? (event as TouchEvent).touches[0].clientY : (event as MouseEvent).clientY;
+      const delta = startY - clientY;
+      const newHeight = currentHeight + delta;
 
-    // vh 기준으로 높이 제한
-    const minPixels = vhToPixels(minHeightVh);
-    const maxPixels = vhToPixels(maxHeightVh);
-    
-    setCurrentHeight(Math.min(Math.max(newHeight, minPixels), maxPixels));
-    setStartY(clientY);
-  }, [isDragging, startY, currentHeight, minHeightVh, maxHeightVh]);
+      // 캐시된 높이 제한값 사용
+      setCurrentHeight(Math.min(Math.max(newHeight, heightLimitsRef.current.min), heightLimitsRef.current.max));
+      setStartY(clientY);
+    },
+    [isDragging, startY, currentHeight]
+  );
 
   const handleDragEnd = useCallback(() => {
     setIsDragging(false);
@@ -44,24 +63,29 @@ export const useBottomSheetDrag = ({
   // 이벤트 핸들러 등록/해제
   const bindDragEvents = useCallback(() => {
     if (isDragging) {
-      window.addEventListener('mousemove', handleDragMove);
-      window.addEventListener('mouseup', handleDragEnd);
-      window.addEventListener('touchmove', handleDragMove);
-      window.addEventListener('touchend', handleDragEnd);
+      window.addEventListener("mousemove", handleDragMove);
+      window.addEventListener("mouseup", handleDragEnd);
+      window.addEventListener("touchmove", handleDragMove);
+      window.addEventListener("touchend", handleDragEnd);
     }
 
     return () => {
-      window.removeEventListener('mousemove', handleDragMove);
-      window.removeEventListener('mouseup', handleDragEnd);
-      window.removeEventListener('touchmove', handleDragMove);
-      window.removeEventListener('touchend', handleDragEnd);
+      window.removeEventListener("mousemove", handleDragMove);
+      window.removeEventListener("mouseup", handleDragEnd);
+      window.removeEventListener("touchmove", handleDragMove);
+      window.removeEventListener("touchend", handleDragEnd);
     };
   }, [isDragging, handleDragMove, handleDragEnd]);
 
   // 화면 크기 변경 시 높이 조정
   const handleResize = useCallback(() => {
     setCurrentHeight(vhToPixels(minHeightVh));
-  }, [minHeightVh]);
+    // 높이 제한값도 업데이트
+    heightLimitsRef.current = {
+      min: vhToPixels(minHeightVh),
+      max: vhToPixels(maxHeightVh)
+    };
+  }, [minHeightVh, maxHeightVh, vhToPixels]);
 
   return {
     currentHeight,

--- a/src/shared/hooks/useBottomSheetDrag.ts
+++ b/src/shared/hooks/useBottomSheetDrag.ts
@@ -11,18 +11,13 @@ export const useBottomSheetDrag = ({
 }: UseBottomSheetDragProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [startY, setStartY] = useState(0);
-  
-  // vh를 픽셀로 변환하는 함수를 메모이제이션
-  const vhToPixels = useCallback((vh: number) => (window.innerHeight * vh) / 100, []);
-  const [currentHeight, setCurrentHeight] = useState(() => vhToPixels(minHeightVh));
+
+  // vh를 픽셀로 변환
+  const vhToPixels = (vh: number) => (window.innerHeight * vh) / 100;
+  const [currentHeight, setCurrentHeight] = useState(vhToPixels(minHeightVh));
 
   // 스크롤 가능한 영역을 ref로 저장
   const scrollableRef = useRef<HTMLElement | null>(null);
-  // 최소/최대 높이를 픽셀로 변환한 값을 캐시
-  const heightLimitsRef = useRef({
-    min: vhToPixels(minHeightVh),
-    max: vhToPixels(maxHeightVh)
-  });
 
   // 컴포넌트 마운트 시 한 번만 스크롤 가능한 영역을 찾음
   useEffect(() => {
@@ -49,11 +44,14 @@ export const useBottomSheetDrag = ({
       const delta = startY - clientY;
       const newHeight = currentHeight + delta;
 
-      // 캐시된 높이 제한값 사용
-      setCurrentHeight(Math.min(Math.max(newHeight, heightLimitsRef.current.min), heightLimitsRef.current.max));
+      // vh 기준으로 높이 제한
+      const minPixels = vhToPixels(minHeightVh);
+      const maxPixels = vhToPixels(maxHeightVh);
+
+      setCurrentHeight(Math.min(Math.max(newHeight, minPixels), maxPixels));
       setStartY(clientY);
     },
-    [isDragging, startY, currentHeight]
+    [isDragging, startY, currentHeight, minHeightVh, maxHeightVh]
   );
 
   const handleDragEnd = useCallback(() => {
@@ -80,12 +78,7 @@ export const useBottomSheetDrag = ({
   // 화면 크기 변경 시 높이 조정
   const handleResize = useCallback(() => {
     setCurrentHeight(vhToPixels(minHeightVh));
-    // 높이 제한값도 업데이트
-    heightLimitsRef.current = {
-      min: vhToPixels(minHeightVh),
-      max: vhToPixels(maxHeightVh)
-    };
-  }, [minHeightVh, maxHeightVh, vhToPixels]);
+  }, [minHeightVh]);
 
   return {
     currentHeight,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,8 @@ export default defineConfig({
       "@": resolve(__dirname, "src"),
     },
   },
+  server: {
+    port: 5173,
+    allowedHosts: true, // 💡 모든 외부 도메인 허용 (개발용으로 안전)
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,8 +15,4 @@ export default defineConfig({
       "@": resolve(__dirname, "src"),
     },
   },
-  server: {
-    port: 5173,
-    allowedHosts: true, // 💡 모든 외부 도메인 허용 (개발용으로 안전)
-  },
 });


### PR DESCRIPTION
# 🛠 구현 사항

- 모바일에서 드래그와 스크롤이 동시에 작동하는 문제를 해결합니다.
- 바텀시트에서 스크롤바의 위치가 최상단에 위치해야 바텀시트를 내릴 수 있게 훅을 수정했습니다.

# ❓ 질문
x

# 📸 화면 캡처
x

# 💬 리뷰 요구사항
- 바텀시트 내부에서 스크롤이 발생하는 영역에 data-scrollable="true"를 작성해서 스크롤 위치를 찾을 수 있게 합니다.
- 스크롤중일때는 드래그를 차단합니다.