### PR TITLE
[feat] : ResizeObserver 적용해 동적 높이 계산

### DIFF
--- a/src/features/mapView/ui/SnapBottomSheet.tsx
+++ b/src/features/mapView/ui/SnapBottomSheet.tsx
@@ -3,7 +3,7 @@ import { BottomSheetContent, FixedButtons } from "./BottomSheetContent";
 
 export const SnapMapBottomSheet = () => {
   return (
-    <SnapBottomSheet snapPoints={[35, 55, 80]} defaultSnap={0}>
+    <SnapBottomSheet>
       <div className="relative">
         <SnapBottomSheet.Header />
         <button className="absolute -top-14 left-1/2 -translate-x-1/2 bg-gray-80 text-white font-semibold text-md px-[24px] py-[12px] rounded-3xl">

--- a/src/features/mapView/ui/SnapBottomSheet.tsx
+++ b/src/features/mapView/ui/SnapBottomSheet.tsx
@@ -3,7 +3,7 @@ import { BottomSheetContent, FixedButtons } from "./BottomSheetContent";
 
 export const SnapMapBottomSheet = () => {
   return (
-    <SnapBottomSheet>
+    <SnapBottomSheet minHeightVh={35}>
       <div className="relative">
         <SnapBottomSheet.Header />
         <button className="absolute -top-14 left-1/2 -translate-x-1/2 bg-gray-80 text-white font-semibold text-md px-[24px] py-[12px] rounded-3xl">

--- a/src/shared/hooks/useBottomSheetSnap.ts
+++ b/src/shared/hooks/useBottomSheetSnap.ts
@@ -14,9 +14,21 @@ export const useSnapPointDrag = ({ snapPoints, defaultSnap }: UseSnapPointDragPr
 
   const startY = useRef(0);
   const startHeight = useRef(height);
+  const prevSnapPoints = useRef(snapPoints);
 
   // 스크롤 가능한 영역을 ref로 저장
   const scrollableRef = useRef<HTMLElement | null>(null);
+
+  // snapPoints가 변경될 때 height 업데이트
+  useEffect(() => {
+    if (JSON.stringify(prevSnapPoints.current) !== JSON.stringify(snapPoints)) {
+      const newSnapHeights = snapPoints.map(vhToPx);
+      const currentSnapIndex = snapHeights.findIndex(h => Math.abs(h - height) < 1);
+      const newHeight = newSnapHeights[currentSnapIndex] ?? newSnapHeights[defaultSnap];
+      setHeight(newHeight);
+      prevSnapPoints.current = snapPoints;
+    }
+  }, [snapPoints, height, defaultSnap, snapHeights]);
 
   // 컴포넌트 마운트 시 한 번만 스크롤 가능한 영역을 찾음
   useEffect(() => {

--- a/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
+++ b/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Portal } from "../Portal";
 
 import { SnapWrapper } from "./SnapWrapper";
@@ -13,8 +13,39 @@ interface BottomSheetProps {
 }
 
 export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSnap = 0 }: BottomSheetProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [dynamicSnapPoints, setDynamicSnapPoints] = useState(snapPoints);
+
+  // ResizeObserver를 사용하여 콘텐츠 높이 측정
+  useEffect(() => {
+    if (!contentRef.current) return;
+
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const contentHeight = entry.contentRect.height;
+        const viewportHeight = window.innerHeight;
+
+        console.log("콘텐츠 높이:", contentHeight, "px");
+        console.log("뷰포트 높이:", viewportHeight, "px");
+        console.log("콘텐츠 높이를 기반으로 vh 계산", (contentHeight / viewportHeight) * 100, "vh");
+
+        // 콘텐츠 높이를 기반으로 동적 snap points 계산
+        const small = 35; // 지도에 맞춰 최소 35vh를 유지한다.
+        const middle = Math.min(50, ((contentHeight * 0.7) / viewportHeight) * 100);
+        const large = Math.min(80, ((contentHeight * 0.9) / viewportHeight) * 100);
+
+        console.log("Calculated snap points:", { small, middle, large });
+
+        setDynamicSnapPoints([small, middle, large]);
+      }
+    });
+
+    observer.observe(contentRef.current);
+    return () => observer.disconnect();
+  }, []);
+
   const { height, isDragging, handlers, bindDragEvents } = useSnapPointDrag({
-    snapPoints,
+    snapPoints: dynamicSnapPoints,
     defaultSnap,
   });
 
@@ -33,6 +64,9 @@ export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSn
         }}
         {...handlers}>
         {children}
+        <div ref={contentRef} className="absolute opacity-0 pointer-events-none">
+          {children}
+        </div>
       </SnapWrapper>
     </Portal>
   );

--- a/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
+++ b/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
@@ -13,7 +13,12 @@ interface BottomSheetProps {
   minHeightVh: number;
 }
 
-export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSnap = 0, minHeightVh }: BottomSheetProps) => {
+export const SnapBottomSheet = ({
+  children,
+  snapPoints = [30, 50, 80],
+  defaultSnap = 0,
+  minHeightVh,
+}: BottomSheetProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [dynamicSnapPoints, setDynamicSnapPoints] = useState(snapPoints);
 
@@ -26,17 +31,10 @@ export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSn
         const contentHeight = entry.contentRect.height;
         const viewportHeight = window.innerHeight;
 
-        console.log("콘텐츠 높이:", contentHeight, "px");
-        console.log("뷰포트 높이:", viewportHeight, "px");
-        console.log("콘텐츠 높이를 기반으로 vh 계산", (contentHeight / viewportHeight) * 100, "vh");
-
         // 콘텐츠 높이를 기반으로 동적 snap points 계산
         const small = minHeightVh; // 지도에 맞춰진 최소 높이
         const middle = Math.min(50, ((contentHeight * 0.7) / viewportHeight) * 100);
         const large = Math.min(80, ((contentHeight * 0.9) / viewportHeight) * 100);
-
-        console.log("Calculated snap points:", { small, middle, large });
-
         setDynamicSnapPoints([small, middle, large]);
       }
     });

--- a/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
+++ b/src/shared/ui/SnapBottomSheet/SnapBottomSheet.tsx
@@ -10,9 +10,10 @@ interface BottomSheetProps {
   children: React.ReactNode;
   snapPoints?: number[];
   defaultSnap?: number;
+  minHeightVh: number;
 }
 
-export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSnap = 0 }: BottomSheetProps) => {
+export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSnap = 0, minHeightVh }: BottomSheetProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [dynamicSnapPoints, setDynamicSnapPoints] = useState(snapPoints);
 
@@ -30,7 +31,7 @@ export const SnapBottomSheet = ({ children, snapPoints = [30, 50, 80], defaultSn
         console.log("콘텐츠 높이를 기반으로 vh 계산", (contentHeight / viewportHeight) * 100, "vh");
 
         // 콘텐츠 높이를 기반으로 동적 snap points 계산
-        const small = 35; // 지도에 맞춰 최소 35vh를 유지한다.
+        const small = minHeightVh; // 지도에 맞춰진 최소 높이
         const middle = Math.min(50, ((contentHeight * 0.7) / viewportHeight) * 100);
         const large = Math.min(80, ((contentHeight * 0.9) / viewportHeight) * 100);
 


### PR DESCRIPTION
# 🛠 구현 사항
- 바텀시트 내부 content의 높이를 ResizeObserver로 트래킹합니다.
- 측정된 content높이 만큼 드래그 가능한 영역인 snap point를 계산합니다. (min(props), 70%, 90%)
- 초기 높이는 props로 "minHeightVh"를 넘겨주면 됩니다.

# ❓ 질문
x

# 📸 화면 캡처
x

# 💬 리뷰 요구사항
- ResizeObserver로 콘텐츠의 실제 높이(px)를 감지
- 뷰포트 높이(window.innerHeight)를 기준으로 콘텐츠 높이의 비율을 vh 단위로 환산
- 콘텐츠 높이의 일정 비율(minHeight(props), 70%, 90%)을 기준으로 snap point 후보 생성
- 이 snap point 후보값이 미리 정한 최대값(35, 50, 80)을 넘지 않도록 Math.min으로 제한
- 최종적으로 [small(props), middle, large] 순으로 스냅 포인트 배열 생성