### PR TITLE
[feat] 유저 정보 조회 및 약관 동의 저장 API 연결

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,29 +1,30 @@
 <!doctype html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
-    <title>SPOT</title>
 
-    <meta name="description" content="모두를 위한 하나의 SPOT" />
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <title>SPOT</title>
 
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="SPOT" />
-    <meta property="og:image" content="" />
-    <meta property="og:url" content="https://meetup-client-silk.vercel.app" />
-    <meta property="og:description" content="모임의 기준을 만들다" />
-    <script
-      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
-      integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
-      crossorigin="anonymous"></script>
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-  </head>
+  <meta name="description" content="우리 모임의 중간지점, 클릭 한 번으로 확인하세요.">
 
-  <body>
-    <div id="root"></div>
-    <div id="portal-root"></div>
-    <script type="module" src="/src/app/main.tsx"></script>
-  </body>
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="SPOT" />
+  <meta property="og:image" content="" />
+  <meta property="og:url" content="https://meetup-client-silk.vercel.app" />
+  <meta property="og:description" content="모임의 기준을 만들다" />
+  <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
+    integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
+    crossorigin="anonymous"></script>
+  <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+</head>
+
+<body>
+  <div id="root"></div>
+  <div id="portal-root"></div>
+  <script type="module" src="/src/app/main.tsx"></script>
+</body>
+
 </html>

--- a/src/features/history/hooks/index.ts
+++ b/src/features/history/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useStoreAgreement";
+export * from "./useUserInfo";

--- a/src/features/history/hooks/useStoreAgreement.ts
+++ b/src/features/history/hooks/useStoreAgreement.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+import { storeUserAgreement } from "../service";
+
+export const useStoreAgreement = () => {
+  return useMutation({
+    mutationFn: storeUserAgreement,
+    onError: error => {
+      console.error("약관 동의 저장 실패: ", error);
+    },
+  });
+};

--- a/src/features/history/hooks/useUserInfo.ts
+++ b/src/features/history/hooks/useUserInfo.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUserInfo } from "../service";
+
+interface UserInfo {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+  personalInfoAgreement: boolean;
+  marketingAgreement: boolean;
+}
+
+export const useUserInfo = () => {
+  return useQuery<UserInfo>({
+    queryKey: ["userInfo"],
+    queryFn: getUserInfo,
+    retry: 2, // 실패 시 최대 두 번 재시도
+    staleTime: 1000 * 60 * 5, // 5분 동안 데이터 캐시 유지
+  });
+};

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,4 +1,5 @@
 import api from "@/shared/api/api";
+import { useMutation } from "@tanstack/react-query";
 
 export const getUserInfo = async () => {
   try {
@@ -15,18 +16,29 @@ export const getUserInfo = async () => {
   }
 };
 
-export const storeAgreement = async (isPersonalInfoAgreement: boolean, isMarketingAgreement: boolean) => {
-  try {
-    const response = await api.post("/users/agreement", { isPersonalInfoAgreement, isMarketingAgreement });
+export const useStoreAgreement = () => {
+  return useMutation({
+    mutationFn: async ({
+      isPersonalInfoAgreement,
+      isMarketingAgreement,
+    }: {
+      isPersonalInfoAgreement: boolean;
+      isMarketingAgreement: boolean;
+    }) => {
+      const response = await api.post("/users/agreement", {
+        isPersonalInfoAgreement,
+        isMarketingAgreement,
+      });
 
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error("서버 에러 발생", response.data.error.message);
-      return false;
-    }
-  } catch (error) {
-    console.error("약관 동의 저장 실패: ", error);
-    return false;
-  }
+      if (response.data.result === "SUCCESS") {
+        return true;
+      } else {
+        console.error("서버 에러 발생", response.data.error.message);
+        throw new Error(response.data.error.message);
+      }
+    },
+    onError: error => {
+      console.error("약관 동의 저장 실패: ", error);
+    },
+  });
 };

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,54 +1,31 @@
 import api from "@/shared/api/api";
-import { useMutation, useQuery } from "@tanstack/react-query";
 
-interface UserInfo {
-  userId: number;
-  nickname: string;
-  profileImageUrl: string;
-  personalInfoAgreement: boolean;
-  marketingAgreement: boolean;
-}
-
-export const useUserInfo = () => {
-  return useQuery<UserInfo>({
-    queryKey: ["userInfo"],
-    queryFn: async () => {
-      const response = await api.get("/users");
-      if (response.data.result === "SUCCESS") {
-        return response.data.data;
-      } else {
-        console.error("서버 에러 발생", response.data.error.message);
-        throw new Error(response.data.error.message);
-      }
-    },
-    retry: 2, // 실패 시 최대 두 번 재시도
-    staleTime: 1000 * 60 * 5, // 5분 동안 데이터 캐시 유지
-  });
+export const getUserInfo = async () => {
+  const response = await api.get("/users");
+  if (response.data.result === "SUCCESS") {
+    return response.data.data;
+  } else {
+    console.error("서버 에러 발생", response.data.error.message);
+    throw new Error(response.data.error.message);
+  }
 };
 
-export const useStoreAgreement = () => {
-  return useMutation({
-    mutationFn: async ({
-      isPersonalInfoAgreement,
-      isMarketingAgreement,
-    }: {
-      isPersonalInfoAgreement: boolean;
-      isMarketingAgreement: boolean;
-    }) => {
-      const response = await api.post("/users/agreement", {
-        isPersonalInfoAgreement,
-        isMarketingAgreement,
-      });
-
-      if (response.data.result === "SUCCESS") {
-        return true;
-      } else {
-        console.error("서버 에러 발생", response.data.error.message);
-        throw new Error(response.data.error.message);
-      }
-    },
-    onError: error => {
-      console.error("약관 동의 저장 실패: ", error);
-    },
+export const storeUserAgreement = async ({
+  isPersonalInfoAgreement,
+  isMarketingAgreement,
+}: {
+  isPersonalInfoAgreement: boolean;
+  isMarketingAgreement: boolean;
+}) => {
+  const response = await api.post("/users/agreement", {
+    isPersonalInfoAgreement,
+    isMarketingAgreement,
   });
+
+  if (response.data.result === "SUCCESS") {
+    return true;
+  } else {
+    console.error("서버 에러 발생", response.data.error.message);
+    throw new Error(response.data.error.message);
+  }
 };

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,19 +1,29 @@
 import api from "@/shared/api/api";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
-export const getUserInfo = async () => {
-  try {
-    const response = await api.get("/users");
-    if (response.data.result === "SUCCESS") {
-      return response.data;
-    } else {
-      console.error("서버 에러 발생", response.data.error.message);
-      return null;
-    }
-  } catch (error) {
-    console.error("유저 정보 조회 실패: ", error);
-    throw error;
-  }
+interface UserInfo {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+  personalInfoAgreement: boolean;
+  marketingAgreement: boolean;
+}
+
+export const useUserInfo = () => {
+  return useQuery<UserInfo>({
+    queryKey: ["userInfo"],
+    queryFn: async () => {
+      const response = await api.get("/users");
+      if (response.data.result === "SUCCESS") {
+        return response.data.data;
+      } else {
+        console.error("서버 에러 발생", response.data.error.message);
+        throw new Error(response.data.error.message);
+      }
+    },
+    retry: 2, // 실패 시 최대 두 번 재시도
+    staleTime: 1000 * 60 * 5, // 5분 동안 데이터 캐시 유지
+  });
 };
 
 export const useStoreAgreement = () => {

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,0 +1,32 @@
+import api from "@/shared/api/api";
+
+export const getUserInfo = async () => {
+  try {
+    const response = await api.get("/users");
+    if (response.data.result === "SUCCESS") {
+      return response.data;
+    } else {
+      console.error("서버 에러 발생", response.data.error.message);
+      return null;
+    }
+  } catch (error) {
+    console.error("유저 정보 조회 실패: ", error);
+    throw error;
+  }
+};
+
+export const storeAgreement = async (isPersonalInfoAgreement: boolean, isMarketingAgreement: boolean) => {
+  try {
+    const response = await api.post("/users/agreement", { isPersonalInfoAgreement, isMarketingAgreement });
+
+    if (response.data.result === "SUCCESS") {
+      return true;
+    } else {
+      console.error("서버 에러 발생", response.data.error.message);
+      return false;
+    }
+  } catch (error) {
+    console.error("약관 동의 저장 실패: ", error);
+    return false;
+  }
+};

--- a/src/features/history/service/index.ts
+++ b/src/features/history/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/features/history/ui/PolicyBottomSheet.tsx
+++ b/src/features/history/ui/PolicyBottomSheet.tsx
@@ -3,7 +3,7 @@ import { Overlay } from "@/shared/ui/BottomSheet/Overlay";
 import Button from "@/shared/ui/Button";
 import { useState } from "react";
 import { CheckBox } from "./CheckBox";
-import { useStoreAgreement } from "../service";
+import { useStoreAgreement } from "../hooks";
 
 interface PolicyBottomSheetProps {
   onClose: () => void;

--- a/src/features/history/ui/PolicyBottomSheet.tsx
+++ b/src/features/history/ui/PolicyBottomSheet.tsx
@@ -3,6 +3,7 @@ import { Overlay } from "@/shared/ui/BottomSheet/Overlay";
 import Button from "@/shared/ui/Button";
 import { useState } from "react";
 import { CheckBox } from "./CheckBox";
+import { storeAgreement } from "../service";
 
 interface PolicyBottomSheetProps {
   onClose: () => void;
@@ -12,9 +13,12 @@ export const PolicyBottomSheet = ({ onClose }: PolicyBottomSheetProps) => {
   const [firstCheckBox, setFirstCheckBox] = useState(false);
   const [secondCheckBox, setSecondCheckBox] = useState(false);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     if (firstCheckBox) {
-      onClose();
+      const isSuccess = await storeAgreement(firstCheckBox, secondCheckBox);
+      if (isSuccess) {
+        onClose();
+      }
     } else {
       setFirstCheckBox(true);
       setSecondCheckBox(true);

--- a/src/features/history/ui/PolicyBottomSheet.tsx
+++ b/src/features/history/ui/PolicyBottomSheet.tsx
@@ -3,22 +3,33 @@ import { Overlay } from "@/shared/ui/BottomSheet/Overlay";
 import Button from "@/shared/ui/Button";
 import { useState } from "react";
 import { CheckBox } from "./CheckBox";
-import { storeAgreement } from "../service";
+import { useStoreAgreement } from "../service";
 
 interface PolicyBottomSheetProps {
   onClose: () => void;
 }
 
 export const PolicyBottomSheet = ({ onClose }: PolicyBottomSheetProps) => {
+  const { mutate } = useStoreAgreement();
   const [firstCheckBox, setFirstCheckBox] = useState(false);
   const [secondCheckBox, setSecondCheckBox] = useState(false);
 
-  const handleClick = async () => {
+  const handleClick = () => {
     if (firstCheckBox) {
-      const isSuccess = await storeAgreement(firstCheckBox, secondCheckBox);
-      if (isSuccess) {
-        onClose();
-      }
+      mutate(
+        {
+          isPersonalInfoAgreement: firstCheckBox,
+          isMarketingAgreement: secondCheckBox,
+        },
+        {
+          onSuccess: () => {
+            onClose();
+          },
+          onError: error => {
+            console.error("약관 동의 요청 실패", error);
+          },
+        }
+      );
     } else {
       setFirstCheckBox(true);
       setSecondCheckBox(true);

--- a/src/features/main/ui/KakaoLogin.tsx
+++ b/src/features/main/ui/KakaoLogin.tsx
@@ -1,6 +1,6 @@
 export const KakaoLogin = () => {
   const handleKakaoLogin = () => {
-    const kakaoAuthUrl = "http://211.188.57.205:8080/oauth2/authorization/kakao";
+    const kakaoAuthUrl = "https://api.pickspot.co.kr/oauth2/authorization/kakao";
     window.location.href = kakaoAuthUrl;
   };
 

--- a/src/features/my/hooks/index.ts
+++ b/src/features/my/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useLogout";

--- a/src/features/my/hooks/useLogout.ts
+++ b/src/features/my/hooks/useLogout.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { logout } from "../service";
+import { useNavigate } from "react-router-dom";
+
+export const useLogout = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      navigate("/");
+    },
+    onError: error => {
+      console.error("로그아웃 실패: ", error);
+    },
+  });
+};

--- a/src/features/my/service/api.ts
+++ b/src/features/my/service/api.ts
@@ -1,19 +1,11 @@
 import api from "@/shared/api/api";
-import { useMutation } from "@tanstack/react-query";
 
-export const useLogout = () => {
-  return useMutation({
-    mutationFn: async () => {
-      const response = await api.post("/auth/logout");
-      if (response.data.result === "SUCCESS") {
-        return true;
-      } else {
-        console.error("서버 에러 발생", response.data.error.message);
-        throw new Error(response.data.error.message);
-      }
-    },
-    onError: error => {
-      console.error("로그아웃 실패: ", error);
-    },
-  });
+export const logout = async () => {
+  const response = await api.post("/auth/logout");
+  if (response.data.result === "SUCCESS") {
+    return true;
+  } else {
+    console.error("서버 에러 발생", response.data.error.message);
+    throw new Error(response.data.error.message);
+  }
 };

--- a/src/features/my/service/api.ts
+++ b/src/features/my/service/api.ts
@@ -1,0 +1,15 @@
+import api from "@/shared/api/api";
+
+export const logout = async () => {
+  try {
+    const response = await api.post("/auth/logout");
+    if (response.data.result === "SUCCESS") {
+      return true;
+    } else {
+      console.error("서버 에러 발생", response.data.error.message);
+      return false;
+    }
+  } catch (error) {
+    console.error("로그아웃 실패: ", error);
+  }
+};

--- a/src/features/my/service/api.ts
+++ b/src/features/my/service/api.ts
@@ -1,15 +1,19 @@
 import api from "@/shared/api/api";
+import { useMutation } from "@tanstack/react-query";
 
-export const logout = async () => {
-  try {
-    const response = await api.post("/auth/logout");
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error("서버 에러 발생", response.data.error.message);
-      return false;
-    }
-  } catch (error) {
-    console.error("로그아웃 실패: ", error);
-  }
+export const useLogout = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await api.post("/auth/logout");
+      if (response.data.result === "SUCCESS") {
+        return true;
+      } else {
+        console.error("서버 에러 발생", response.data.error.message);
+        throw new Error(response.data.error.message);
+      }
+    },
+    onError: error => {
+      console.error("로그아웃 실패: ", error);
+    },
+  });
 };

--- a/src/features/my/service/index.ts
+++ b/src/features/my/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/features/my/ui/Logout.tsx
+++ b/src/features/my/ui/Logout.tsx
@@ -1,9 +1,12 @@
-import { logout } from "../service";
+import { useLogout } from "../service";
+
+//@TODO 로그아웃 처리 관련 논의 필요, 로그아웃 로딩중 처리
 
 export const Logout = () => {
+  const { mutate } = useLogout();
+
   const handleClick = async () => {
-    const isSuccess = await logout();
-    console.log(isSuccess); // @TODO 로그아웃 처리를 어떻게 구현할지 고민!
+    mutate();
   };
 
   return (

--- a/src/features/my/ui/Logout.tsx
+++ b/src/features/my/ui/Logout.tsx
@@ -1,6 +1,15 @@
+import { logout } from "../service";
+
 export const Logout = () => {
+  const handleClick = async () => {
+    const isSuccess = await logout();
+    console.log(isSuccess); // @TODO 로그아웃 처리를 어떻게 구현할지 고민!
+  };
+
   return (
-    <button className="w-full h-[44px] flex gap-2 items-center justify-center bg-gray-5 rounded-xl">
+    <button
+      className="w-full h-[44px] flex gap-2 items-center justify-center bg-gray-5 rounded-xl"
+      onClick={handleClick}>
       <img src="/icon/logout.svg" alt="logout" />
       <p className="text-md font-medium text-gray-60">로그아웃</p>
     </button>

--- a/src/features/my/ui/Logout.tsx
+++ b/src/features/my/ui/Logout.tsx
@@ -1,6 +1,4 @@
-import { useLogout } from "../service";
-
-//@TODO 로그아웃 처리 관련 논의 필요, 로그아웃 로딩중 처리
+import { useLogout } from "../hooks";
 
 export const Logout = () => {
   const { mutate } = useLogout();

--- a/src/features/my/ui/Profile.tsx
+++ b/src/features/my/ui/Profile.tsx
@@ -1,9 +1,10 @@
+import { useUserStore } from "@/shared/stores";
 import { useState } from "react";
 
 //@TODO 백 연동 시 이름, 프로필사진, 이메일 수정
 export const Profile = () => {
+  const { nickname, setNickname, profileImageUrl } = useUserStore();
   const [isEditting, setIsEditting] = useState(false);
-  const [name, setName] = useState("");
 
   const handleEditting = () => {
     setIsEditting(true);
@@ -23,21 +24,21 @@ export const Profile = () => {
 
   return (
     <div className="flex py-3 gap-3 items-center">
-      <img src="https://github.com/shadcn.png" alt="profileImg" className="w-16 h-16 rounded-full" />
+      <img src={profileImageUrl} alt="profileImg" className="w-16 h-16 rounded-full" />
       <div className="flex flex-col gap-1 w-full">
         {isEditting ? (
           <input
             type="text"
             className="rounded-none w-full border-b-gray-90 border-b outline-none text-lg font-semibold text-gray-90"
-            value={name}
-            onChange={e => setName(e.target.value)}
+            value={nickname}
+            onChange={e => setNickname(e.target.value)}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
             autoFocus
           />
         ) : (
           <div className="flex gap-1 items-center">
-            <span className="text-lg font-semibold text-gray-90">{name}</span>
+            <span className="text-lg font-semibold text-gray-90">{nickname}</span>
             <button onClick={handleEditting}>
               <img src="/icon/edit.svg" alt="edit" />
             </button>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,10 +1,11 @@
-import { getUserInfo } from "@/features/history/service";
+import { useUserInfo } from "@/features/history/service";
 import { Banner, Empty, Header, GroupCard, PolicyBottomSheet } from "@/features/history/ui";
 import { mockListData } from "@/shared/model";
 import { useUserStore } from "@/shared/stores";
 import { useEffect, useState } from "react";
 
 const HistoryPage = () => {
+  const { data, isLoading, isError } = useUserInfo();
   const [isPolicy, setIsPolicy] = useState(false);
   const { profileImageUrl } = useUserStore();
   const length = 1; // 임시 ui 구현을 위한 작업!
@@ -14,19 +15,17 @@ const HistoryPage = () => {
   };
 
   useEffect(() => {
-    const fetchData = async () => {
-      const response = await getUserInfo();
-      if (response.data) {
-        useUserStore.setState({
-          nickname: response.data.nickname,
-          profileImageUrl: response.data.profileImageUrl,
-        });
-        setIsPolicy(!response.data.personalInfoAgreement);
-      }
-    };
+    if (data) {
+      useUserStore.setState({
+        nickname: data.nickname,
+        profileImageUrl: data.profileImageUrl,
+      });
+      setIsPolicy(!data.personalInfoAgreement);
+    }
+  }, [data]);
 
-    fetchData();
-  }, []);
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError) return <p>유저 정보를 가져오는 데 실패했습니다.</p>;
 
   return (
     <div className="flex flex-col h-screen-dvh">

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,19 +1,37 @@
+import { getUserInfo } from "@/features/history/service";
 import { Banner, Empty, Header, GroupCard, PolicyBottomSheet } from "@/features/history/ui";
 import { mockListData } from "@/shared/model";
-import { useState } from "react";
+import { useUserStore } from "@/shared/stores";
+import { useEffect, useState } from "react";
 
 const HistoryPage = () => {
+  const [isPolicy, setIsPolicy] = useState(false);
+  const { profileImageUrl } = useUserStore();
   const length = 1; // 임시 ui 구현을 위한 작업!
-  const [isPolicy, setIsPolicy] = useState(true);
 
-  const handleClick = () => {
+  const onClose = () => {
     setIsPolicy(false);
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await getUserInfo();
+      if (response.data) {
+        useUserStore.setState({
+          nickname: response.data.nickname,
+          profileImageUrl: response.data.profileImageUrl,
+        });
+        setIsPolicy(!response.data.personalInfoAgreement);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   return (
     <div className="flex flex-col h-screen-dvh">
       <div className="flex flex-col px-5 gap-2">
-        <Header profileImg="https://github.com/shadcn.png" />
+        <Header profileImg={profileImageUrl} />
         <Banner />
         <span className="mt-4 py-3 text-lg font-bold">나의 모임</span>
       </div>
@@ -26,7 +44,7 @@ const HistoryPage = () => {
       ) : (
         <Empty />
       )}
-      {isPolicy && <PolicyBottomSheet onClose={handleClick} />}
+      {isPolicy && <PolicyBottomSheet onClose={onClose} />}
     </div>
   );
 };

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useUserInfo } from "@/features/history/service";
+import { useUserInfo } from "@/features/history/hooks";
 import { Banner, Empty, Header, GroupCard, PolicyBottomSheet } from "@/features/history/ui";
 import { mockListData } from "@/shared/model";
 import { useUserStore } from "@/shared/stores";

--- a/src/shared/stores/index.ts
+++ b/src/shared/stores/index.ts
@@ -1,2 +1,3 @@
 export * from "./useFindStore";
 export * from "./useMapStore";
+export * from "./userStore";

--- a/src/shared/stores/userStore.ts
+++ b/src/shared/stores/userStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface UserState {
+  nickname: string;
+  profileImageUrl: string;
+  setNickname: (nickname: string) => void;
+  setProfileImgUrl: (url: string) => void;
+}
+
+export const useUserStore = create<UserState>(set => ({
+  nickname: "",
+  profileImageUrl: "",
+  setNickname: nickname => set({ nickname }),
+  setProfileImgUrl: url => set({ profileImageUrl: url }),
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,8 @@ export default defineConfig({
       "@": resolve(__dirname, "src"),
     },
   },
+  server: {
+    port: 5173,
+    allowedHosts: true,
+  },
 });


### PR DESCRIPTION
# 🛠 구현 사항

- 메타 태그 적용
- ngrok vite.config 수정
- 유저 정보 조회 API 연결
- 약관 동의 저장 API 연결
- 로그아웃 임시 구현
- MY 페이지 이름, 프로필사진 적용

# ❓ 질문

-  X

# 📸 화면 캡처
![image](https://github.com/user-attachments/assets/deec3142-400c-45d3-ab04-95e4e8683f4c)
(이용약관 동의 후 true로 변경 완료!)
![image](https://github.com/user-attachments/assets/094cf522-4747-4fb8-b395-87dedf960deb)

# 💬 리뷰 요구사항
1. 약관 동의 저장 API 연결 시 약관 동의를 해버려가지고 다양한 테스트를 못해봤습니다.. (모두 동의하고 완료 누르고 모달 잘 닫히는지 확인해야합니다!)
2. 현재 유저 정보로 닉네임과 프로필 사진을 받아오는데 이는 hi, my 페이지에 사용되고 한 곳에서만 불러오고 전역적으로 관리하고자 userStore로 관리하고 있습니다. (추후, 이메일이 추가된다면 세가지 다 zustand로 가져가는 거 괜찮을지 궁금합니다!)
3. 로그인을 했는지 유무를 판단하는 지표가 있어야 할 것 같습니다. 이 지표로 로그인을 안했을 경우 접근할 수 없는 페이지 막기, 로그아웃 시 리다이렉트 시키기 등을 작업해야할 것 같아요. 현재 로그아웃 시 쿠키는 삭제 되는 것 같은데 별다른 동작이 없어서 로그아웃이 실제로 잘 됐는지 유저가 알 수 없어서 어떻게 하면 좋을까용.. ? ma 페이지로 리다이렉트 시키는게 나을까요?