### PR TITLE
[feat] : mp페이지 event조회 api 연결

### DIFF
--- a/src/features/find/hooks/useCreateStartPoint.ts
+++ b/src/features/find/hooks/useCreateStartPoint.ts
@@ -13,13 +13,8 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
     onSuccess: response => {
       const { eventId, startPointId } = response.data;
 
-      // 쿠키가 없을 때만 저장
-      if (!getCookie("eventId")) {
-        setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
-      }
-      if (!getCookie("startPointId")) {
-        setCookie("startPointId", startPointId, { path: "/", maxAge: 86400 });
-      }
+      setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
+      setCookie("startPointId", startPointId, { path: "/", maxAge: 86400 });
 
       // 페이지 이동
       navigate(`/mapview?eventId=${eventId}`);

--- a/src/features/find/hooks/useCreateStartPoint.ts
+++ b/src/features/find/hooks/useCreateStartPoint.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { addMember, createEvent } from "../service";
 import { FormattedData } from "../model";
-import { setCookie } from "@/shared/utils";
+import { getCookie, setCookie } from "@/shared/utils";
 
 export const useCreateStartPoint = (eventIdParam: string | null) => {
   const navigate = useNavigate();
@@ -13,9 +13,13 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
     onSuccess: response => {
       const { eventId, startPointId } = response.data;
 
-      // 쿠키 저장
-      setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
-      setCookie("startPointId", startPointId, { path: "/", maxAge: 86400 });
+      // 쿠키가 없을 때만 저장
+      if (!getCookie("eventId")) {
+        setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
+      }
+      if (!getCookie("startPointId")) {
+        setCookie("startPointId", startPointId, { path: "/", maxAge: 86400 });
+      }
 
       // 페이지 이동
       navigate(`/mapview?eventId=${eventId}`);
@@ -28,7 +32,10 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
   const { mutate: addMemberMutate } = useMutation({
     mutationFn: ({ payload, eventId }: { payload: FormattedData; eventId: string }) => addMember(payload, eventId),
     onSuccess: response => {
-      setCookie("startPointId", response.data.startPointId, { path: "/", maxAge: 86400 });
+      // 쿠키가 없을 때만 저장
+      if (!getCookie("startPointId")) {
+        setCookie("startPointId", response.data.startPointId, { path: "/", maxAge: 86400 });
+      }
       navigate(`/mapview?eventId=${eventIdParam}`);
     },
     onError: error => {

--- a/src/features/mapView/hooks/useEventInfo.ts
+++ b/src/features/mapView/hooks/useEventInfo.ts
@@ -15,6 +15,5 @@ export const useEventRoutes = () => {
       return getEventInfo(eventId, startPointId);
     },
     enabled: !!eventId, // eventId가 있을 때만 요청
-    staleTime: 1000 * 60 * 1, // 1분 캐싱
   });
 };

--- a/src/features/mapView/hooks/useEventInfo.ts
+++ b/src/features/mapView/hooks/useEventInfo.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCookie } from "@/shared/utils";
+import { getEventInfo } from "../service";
+import { useSearchParams } from "react-router-dom";
+
+export const useEventRoutes = () => {
+  const [searchParams] = useSearchParams();
+  const eventId = searchParams.get("eventId");
+  const startPointId = getCookie("startPointId");
+
+  return useQuery({
+    queryKey: ["eventRoutes", eventId, startPointId],
+    queryFn: () => {
+      if (!eventId) throw new Error("eventId가 없습니다.");
+      return getEventInfo(eventId, startPointId);
+    },
+    enabled: !!eventId, // eventId가 있을 때만 요청
+    staleTime: 1000 * 60 * 1, // 1분 캐싱
+  });
+};

--- a/src/features/mapView/service/api.ts
+++ b/src/features/mapView/service/api.ts
@@ -1,0 +1,22 @@
+import api from "@/shared/api/api";
+import { GetEventRouteResponse } from "@/shared/model";
+
+export const getEventInfo = async (eventId: string, startPointId?: string) => {
+  try {
+    const response = await api.get<{
+      result: string;
+      data: GetEventRouteResponse;
+      error?: {
+        code: string;
+        message: string;
+      };
+    }>(`/events/${eventId}`, {
+      params: startPointId ? { startPointId } : {},
+    });
+
+    return response.data.data;
+  } catch (error) {
+    console.error("모임 경로 조회 실패:", error);
+    throw error;
+  }
+};

--- a/src/features/mapView/service/index.ts
+++ b/src/features/mapView/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -1,4 +1,4 @@
-import { useMapStore } from "@/shared/stores";
+import { useEventStore, useMapStore } from "@/shared/stores";
 import { UserCard } from "./UserCard";
 import { useState } from "react";
 import { LoginModal } from ".";
@@ -6,6 +6,7 @@ import { ShareModal } from "@/shared/ui";
 
 export const BottomSheetContent = () => {
   const { users, meetingPoint } = useMapStore();
+  const eventData = useEventStore(state => state.eventData);
 
   return (
     <div className="h-full flex flex-col">
@@ -17,8 +18,8 @@ export const BottomSheetContent = () => {
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto mx-5 pb-[80px] scrollbar-hidden" data-scrollable="true">
-        {users.map(user => (
-          <UserCard key={user.id} name={user.name} startStation={user.startStation} totalTime={user.totalTime} />
+        {eventData?.routeResponse.map(user => (
+          <UserCard key={user.id} name={user.nickname} startStation={user.startName} totalTime={user.totalTime} />
         ))}
       </div>
     </div>

--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -1,8 +1,9 @@
-import { useEventStore } from "@/shared/stores";
+import { useEventStore, useUserStore } from "@/shared/stores";
 import { UserCard } from "./UserCard";
 import { useState } from "react";
 import { LoginModal } from ".";
 import { ShareModal } from "@/shared/ui";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 export const BottomSheetContent = () => {
   const eventData = useEventStore(state => state.eventData);
@@ -27,7 +28,7 @@ export const BottomSheetContent = () => {
 
 export const FixedButtons = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [isOpenLoginModal, setIsOpenLoginModal] = useState(false); // 추후 로그인 상태인지 검증하는 로직 구현예정
+  const [isOpenLoginModal, setIsOpenLoginModal] = useState(false);
   const eventId = new URLSearchParams(window.location.search).get("eventId");
   const shareContent = {
     title: "님이 모임을 생성했어요",
@@ -38,13 +39,25 @@ export const FixedButtons = () => {
       { label: "중간지점 보기", url: `https://meetup-client-silk.vercel.app/mapView?eventId=${eventId}` },
     ],
   };
+  const nickname = useUserStore(state => state.nickname);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const eventIdParam = searchParams.get("eventId");
+
+  const handleAddMemberClick = () => {
+    if (nickname) {
+      navigate(`/find?eventId=${eventIdParam}`);
+    } else {
+      setIsOpenLoginModal(true);
+    }
+  };
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white p-5">
       <div className="flex flex-row gap-2">
         <button
           className="flex flex-row items-center justify-center gap-2 rounded-md bg-sub-sub h-[40px] text-white font-semibold text-sm w-full"
-          onClick={() => setIsOpenLoginModal(true)}>
+          onClick={handleAddMemberClick}>
           <img src="./icon/addUser.svg" alt="addUser" />
           <span>멤버 추가하기</span>
         </button>

--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -4,9 +4,22 @@ import { useState } from "react";
 import { LoginModal } from ".";
 import { ShareModal } from "@/shared/ui";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { getCookie } from "@/shared/utils";
 
 export const BottomSheetContent = () => {
   const eventData = useEventStore(state => state.eventData);
+  const startPointId = getCookie("startPointId");
+
+  // 정렬된 routeResponse 만들기
+  const sortedRouteResponse = (() => {
+    if (!eventData?.routeResponse || !startPointId) return eventData?.routeResponse;
+
+    const matched = eventData.routeResponse.find(user => user.id === startPointId);
+    const others = eventData.routeResponse.filter(user => user.id !== startPointId);
+
+    return matched ? [matched, ...others] : eventData.routeResponse;
+  })();
+  console.log(sortedRouteResponse);
 
   return (
     <div className="h-full flex flex-col">
@@ -18,7 +31,7 @@ export const BottomSheetContent = () => {
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto mx-5 pb-[80px] scrollbar-hidden" data-scrollable="true">
-        {eventData?.routeResponse.map(user => (
+        {sortedRouteResponse?.map(user => (
           <UserCard key={user.id} name={user.nickname} startStation={user.startName} totalTime={user.totalTime} />
         ))}
       </div>

--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -1,19 +1,18 @@
-import { useEventStore, useMapStore } from "@/shared/stores";
+import { useEventStore } from "@/shared/stores";
 import { UserCard } from "./UserCard";
 import { useState } from "react";
 import { LoginModal } from ".";
 import { ShareModal } from "@/shared/ui";
 
 export const BottomSheetContent = () => {
-  const { users, meetingPoint } = useMapStore();
   const eventData = useEventStore(state => state.eventData);
 
   return (
     <div className="h-full flex flex-col">
       <div className="mx-5">
         <div>
-          <h1 className="text-gray-80 text-lg font-bold">{meetingPoint.stationName}</h1>
-          <p className="text-gray-40 text-md">{meetingPoint.averageDuration}</p>
+          <h1 className="text-gray-80 text-lg font-bold">{eventData?.meetingPoint.endStationName}</h1>
+          <p className="text-gray-40 text-md">평균 {eventData?.averageTime}분</p>
         </div>
       </div>
 

--- a/src/features/mapView/ui/BottomSheetContent.tsx
+++ b/src/features/mapView/ui/BottomSheetContent.tsx
@@ -4,22 +4,9 @@ import { useState } from "react";
 import { LoginModal } from ".";
 import { ShareModal } from "@/shared/ui";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { getCookie } from "@/shared/utils";
 
 export const BottomSheetContent = () => {
   const eventData = useEventStore(state => state.eventData);
-  const startPointId = getCookie("startPointId");
-
-  // 정렬된 routeResponse 만들기
-  const sortedRouteResponse = (() => {
-    if (!eventData?.routeResponse || !startPointId) return eventData?.routeResponse;
-
-    const matched = eventData.routeResponse.find(user => user.id === startPointId);
-    const others = eventData.routeResponse.filter(user => user.id !== startPointId);
-
-    return matched ? [matched, ...others] : eventData.routeResponse;
-  })();
-  console.log(sortedRouteResponse);
 
   return (
     <div className="h-full flex flex-col">
@@ -31,7 +18,7 @@ export const BottomSheetContent = () => {
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto mx-5 pb-[80px] scrollbar-hidden" data-scrollable="true">
-        {sortedRouteResponse?.map(user => (
+        {eventData?.routeResponse.map(user => (
           <UserCard key={user.id} name={user.nickname} startStation={user.startName} totalTime={user.totalTime} />
         ))}
       </div>

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -41,7 +41,7 @@ export function KakaoMapView() {
             bounds.extend(new window.kakao.maps.LatLng(user.startLatitude, user.startLongitude));
           });
 
-          kakaoMap.setBounds(bounds, 40);
+          kakaoMap.setBounds(bounds, 40); //bounds 40px 여백 설정
         }
       });
     };

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -41,7 +41,7 @@ export function KakaoMapView() {
             bounds.extend(new window.kakao.maps.LatLng(user.startLatitude, user.startLongitude));
           });
 
-          kakaoMap.setBounds(bounds);
+          kakaoMap.setBounds(bounds, 40);
         }
       });
     };

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -60,7 +60,7 @@ export function KakaoMapView() {
       };
       document.head.appendChild(script);
     }
-  }, []);
+  }, [eventData]);
 
   const drawPolylines = () => {
     if (!map || !center) return;

--- a/src/features/mapView/ui/MapMarker.tsx
+++ b/src/features/mapView/ui/MapMarker.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 interface MapMarkerProps {
   map: kakao.maps.Map;
   position: { lat: number; lng: number };
-  profileImg?: string;
+  profileImg: string | null;
   name?: string;
   onClick?: () => void;
 }

--- a/src/features/mapView/ui/UserCard.tsx
+++ b/src/features/mapView/ui/UserCard.tsx
@@ -1,7 +1,7 @@
 interface UserCardProps {
   name: string;
   startStation: string;
-  totalTime: string;
+  totalTime: number;
   onClick?: () => void;
 }
 

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -1,3 +1,4 @@
+import { useEventRoutes } from "@/features/mapView/hooks/useEventInfo";
 import {
   AddMemberBottomSheet,
   DetailKakaoMapView,
@@ -7,31 +8,49 @@ import {
   SnapMapBottomSheet,
   TooCloseSheet,
 } from "@/features/mapView/ui";
-import { useState } from "react";
+import { useEventStore } from "@/shared/stores";
+import { AxiosError } from "axios";
+import { useEffect, useState } from "react";
 
 const MapViewPage = () => {
   const isDetail = false; // 임시 작업
   const openDetailBottomSheet = true; // 임시 작업
   const memberCount = 2; // 임시 인원 설정
 
+  const { data, isLoading, isError, error } = useEventRoutes();
+  const setEventData = useEventStore(state => state.setEventData);
+
   const [midpointError, setMidpointError] = useState(false); // 중간지점 산출 실패 상태
   void setMidpointError; // 빌드에러 방지를 위한 임시 처리
+
+  const errorCode = (error as AxiosError<{ error: { code: string } }>)?.response?.data?.error?.code;
+  const isInsufficientStartPoints = errorCode === "INSUFFICIENT_START_POINTS";
+
+  useEffect(() => {
+    if (data) {
+      setEventData(data);
+    }
+  }, [data, setEventData]);
 
   return (
     <div>
       <MapHeader />
-      {midpointError ? (
-        <TooCloseSheet />
+      <KakaoMapView />
+      {isLoading ? (
+        <div>실시간 교통상황을 가져오고 있습니다...</div>
+      ) : isError ? (
+        isInsufficientStartPoints ? (
+          <AddMemberBottomSheet />
+        ) : (
+          <TooCloseSheet />
+        )
       ) : isDetail ? (
         <>
           <DetailKakaoMapView />
           {openDetailBottomSheet && <MapDetailBottomSheet />}
         </>
       ) : (
-        <>
-          <KakaoMapView />
-          {memberCount >= 2 ? <SnapMapBottomSheet /> : <AddMemberBottomSheet />}
-        </>
+        <>{memberCount >= 2 ? <SnapMapBottomSheet /> : <AddMemberBottomSheet />}</>
       )}
     </div>
   );

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/features/mapView/ui";
 import { useEventStore } from "@/shared/stores";
 import { AxiosError } from "axios";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 const MapViewPage = () => {
   const isDetail = false; // 임시 작업
@@ -20,8 +20,7 @@ const MapViewPage = () => {
   const { data, isLoading, isError, error } = useEventRoutes();
   const setEventData = useEventStore(state => state.setEventData);
 
-  const [midpointError, setMidpointError] = useState(false); // 중간지점 산출 실패 상태
-  void setMidpointError; // 빌드에러 방지를 위한 임시 처리
+  // const [midpointError, setMidpointError] = useState(false); // 중간지점 산출 실패 상태
 
   const errorCode = (error as AxiosError<{ error: { code: string } }>)?.response?.data?.error?.code;
   const isInsufficientStartPoints = errorCode === "INSUFFICIENT_START_POINTS";

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -35,7 +35,6 @@ const MapViewPage = () => {
   return (
     <div>
       <MapHeader />
-      <KakaoMapView />
       {isLoading ? (
         <div>실시간 교통상황을 가져오고 있습니다...</div>
       ) : isError ? (
@@ -50,7 +49,10 @@ const MapViewPage = () => {
           {openDetailBottomSheet && <MapDetailBottomSheet />}
         </>
       ) : (
-        <>{memberCount >= 2 ? <SnapMapBottomSheet /> : <AddMemberBottomSheet />}</>
+        <>
+          <KakaoMapView />
+          {memberCount >= 2 ? <SnapMapBottomSheet /> : <AddMemberBottomSheet />}
+        </>
       )}
     </div>
   );

--- a/src/shared/model/event.type.ts
+++ b/src/shared/model/event.type.ts
@@ -1,0 +1,61 @@
+export interface MeetingPoint {
+  endStationName: string;
+  endLongitude: number;
+  endLatitude: number;
+}
+
+export interface TransitRoute {
+  trafficType: string;
+  distance: number;
+  sectionTime: number;
+  stationCount: number;
+
+  // type에 따른 선택적 필드들
+  startExitNo?: string;
+  endExitNo?: string;
+  laneName?: string;
+  startBoardName?: string;
+  endBoardName?: string;
+  passStopList?: {
+    stations: {
+      index: number;
+      stationName: string;
+      x: string;
+      y: string;
+    }[];
+  };
+}
+
+export interface DrivingRoute {
+  taxi: number;
+  toll: number;
+  duration: number;
+  distance: number;
+}
+
+export interface RouteResponse {
+  isTransit: boolean;
+  isMe: boolean;
+  id: string;
+  nickname: string;
+  profileImage: string | null;
+  startName: string;
+  startLongitude: number;
+  startLatitude: number;
+  transitRoute: TransitRoute[];
+  drivingRoute: DrivingRoute[];
+  totalTime: number;
+}
+
+export interface ParkingLot {
+  name: string;
+  distance: number;
+}
+
+export interface GetEventRouteResponse {
+  peopleCount: number;
+  averageTime: number;
+  meetingPoint: MeetingPoint;
+  routeResponse: RouteResponse[];
+  parkingLot: ParkingLot;
+}

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -1,3 +1,4 @@
 export * from "./mocks/mockListData";
 export * from "./mocks/mockMapData";
 export * from "./kakaoShare.type";
+export * from "./event.type";

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -18,7 +18,7 @@ declare global {
 
       class Map {
         constructor(container: HTMLElement, options: { center: LatLng; level: number });
-        setBounds(bounds: LatLngBounds): void;
+        setBounds(bounds: LatLngBounds, padding?: number): void;
       }
 
       class Marker {
@@ -71,11 +71,7 @@ declare global {
         };
 
         class Geocoder {
-          coord2Address(
-            longitude: number,
-            latitude: number,
-            callback: (result: any, status: string) => void
-          ): void;
+          coord2Address(longitude: number, latitude: number, callback: (result: any, status: string) => void): void;
         }
       }
     }

--- a/src/shared/stores/index.ts
+++ b/src/shared/stores/index.ts
@@ -1,2 +1,3 @@
 export * from "./useMapStore";
 export * from "./userStore";
+export * from "./useEventStore";

--- a/src/shared/stores/useEventStore.ts
+++ b/src/shared/stores/useEventStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { GetEventRouteResponse } from "../model";
+
+interface EventStoreState {
+  eventData: GetEventRouteResponse | null;
+  setEventData: (data: GetEventRouteResponse) => void;
+  clearEventData: () => void;
+}
+
+export const useEventStore = create<EventStoreState>()(
+  devtools(set => ({
+    eventData: null,
+    setEventData: data => set({ eventData: data }),
+    clearEventData: () => set({ eventData: null }),
+  }))
+);


### PR DESCRIPTION
# 🛠 구현 사항
- mp페이지 api를 연동
- 서버 응답에 맞게 props 조정 및 타입 수정
- polyline 연결
- 자가용, 대중교통 상태 isTrasit에 따른 polyline 연결
- bounds의 padding을 40px을 적용

# ❓ 질문
- find 페이지에서 이벤트를 생성하거나 출발지를 입력하면 쿠키를 저장하게 되는데, 쿠키의 만료시간을 어떻게 하면 좋을지, 삭제되는 시점은 어떻게 처리할지가 고민입니다!

# 📸 화면 캡처
<img width="378" alt="스크린샷 2025-05-13 오후 1 06 17" src="https://github.com/user-attachments/assets/b0dac27d-e91f-4aa8-be6f-cb771b7c1d84" />
<img width="374" alt="스크린샷 2025-05-13 오후 3 29 38" src="https://github.com/user-attachments/assets/660ee84e-da7a-4b01-a47c-5d494facb062" />

# 💬 리뷰 요구사항
- 서버로 부터 받은 event respones는 mp페이지의 각 지도와 바텀시트, 조건분기가 많아 zustand로 관리하는게 맞다고 판단했습니다. userEventStore로 사용하시면 됩니다!
- 여러 사용자의 경로는 isTransit이 true인경우 대중교통 위도, 경도를 polyline path에 추가했고 false면 추가하지않고 중간지점을 바로 연결하도록 했습니다.
- 추가로 지도 마커들의 bounds에 40px을 추가하여 마커가 화면 끝에 위치하는 경우를 방지했습니다.