### PR TITLE
[fix] : 지하철 노선명에 따른 컴포넌트 렌더링 문제 해결

### DIFF
--- a/src/features/mapView/config/subwayLine.ts
+++ b/src/features/mapView/config/subwayLine.ts
@@ -1,4 +1,4 @@
-export const metroNameToKey: Record<string, { bg: string; text?: string }> = {
+export const subwayLine: Record<string, { bg: string; text?: string }> = {
   "수도권 공항철도": { bg: "bg-metro-KA" },
   "수도권 신분당선": { bg: "bg-metro-S" },
   "수도권 우이신설경전철": { bg: "bg-metro-UI" },

--- a/src/features/mapView/model/openMap.type.ts
+++ b/src/features/mapView/model/openMap.type.ts
@@ -1,5 +1,5 @@
 export interface OpenMapProps {
   endPoint: string;
   endLat: number;
-  endLog: number;
+  endLng: number;
 }

--- a/src/features/mapView/ui/DetailBottomSheet/SubwayPath.tsx
+++ b/src/features/mapView/ui/DetailBottomSheet/SubwayPath.tsx
@@ -1,8 +1,17 @@
 import { TransitRoute } from "@/shared/model";
-import { metroNameToKey } from "../../config/subwayLine";
+import { subwayLine } from "../../config/subwayLine";
 
 export const SubwayPath = ({ endBoardName, laneName, sectionTime, startBoardName, stationCount }: TransitRoute) => {
-  const lineType = metroNameToKey[laneName!];
+  const findMetroKey = (lineName: string) => {
+    if (subwayLine[lineName]) return subwayLine[lineName];
+
+    const foundKey = Object.keys(subwayLine).find(key => lineName.startsWith(key));
+    return foundKey ? subwayLine[foundKey] : null;
+  };
+
+  const lineType = findMetroKey(laneName!);
+
+  if (!lineType) return null;
 
   return (
     <>

--- a/src/features/mapView/ui/DetailBottomSheet/TransferDetail.tsx
+++ b/src/features/mapView/ui/DetailBottomSheet/TransferDetail.tsx
@@ -26,9 +26,11 @@ export const TransferDetail = ({ type, averageDuration, startPoint, endPoint }: 
         alt: "kakaoMap",
         onClick: () =>
           openKakaoMap({
+            startLat: detailEventData.startLatitude,
+            startLng: detailEventData.startLongitude,
             endPoint: eventData.meetingPoint.endStationName,
             endLat: eventData.meetingPoint.endLatitude,
-            endLog: eventData.meetingPoint.endLongitude,
+            endLng: eventData.meetingPoint.endLongitude,
           }),
       },
       {
@@ -38,10 +40,10 @@ export const TransferDetail = ({ type, averageDuration, startPoint, endPoint }: 
           openNaverMap({
             startPoint: detailEventData.startName,
             startLat: detailEventData.startLatitude,
-            startLog: detailEventData.startLongitude,
+            startLng: detailEventData.startLongitude,
             endPoint: eventData.meetingPoint.endStationName,
             endLat: eventData.meetingPoint.endLatitude,
-            endLog: eventData.meetingPoint.endLongitude,
+            endLng: eventData.meetingPoint.endLongitude,
           }),
       },
     ],
@@ -53,7 +55,7 @@ export const TransferDetail = ({ type, averageDuration, startPoint, endPoint }: 
           openTMAP({
             endPoint: eventData.meetingPoint.endStationName,
             endLat: eventData.meetingPoint.endLatitude,
-            endLog: eventData.meetingPoint.endLongitude,
+            endLng: eventData.meetingPoint.endLongitude,
           }),
       },
     ],

--- a/src/features/mapView/utils/kakaoMap.ts
+++ b/src/features/mapView/utils/kakaoMap.ts
@@ -10,7 +10,7 @@ export const openKakaoMap = ({ startLat, startLng, endPoint, endLat, endLng }: O
   const kakaoMapUrl = `https://map.kakao.com/link/to/${endPoint},${endLat},${endLng}`;
   window.open(kakaoAppUrl, "_blank");
 
-  // APP이 설치되어 있지 않으면 웹으로 리다이렉트트
+  // APP이 설치되어 있지 않으면 웹으로 리다이렉트
   setTimeout(() => {
     if (!document.hidden) {
       window.open(kakaoMapUrl, "_blank");

--- a/src/features/mapView/utils/kakaoMap.ts
+++ b/src/features/mapView/utils/kakaoMap.ts
@@ -1,6 +1,19 @@
 import { OpenMapProps } from "../model";
 
-export const openKakaoMap = ({ endPoint, endLat, endLog }: OpenMapProps) => {
-  const kakaoMapUrl = `https://map.kakao.com/link/to/${endPoint},${endLat},${endLog}`;
-  window.open(kakaoMapUrl, "_blank");
+interface OpenKakaoMapProps extends OpenMapProps {
+  startLat: number;
+  startLng: number;
+}
+
+export const openKakaoMap = ({ startLat, startLng, endPoint, endLat, endLng }: OpenKakaoMapProps) => {
+  const kakaoAppUrl = `kakaomap://route?sp=${startLat},${startLng}&ep=${endLat},${endLng}&by=CAR`;
+  const kakaoMapUrl = `https://map.kakao.com/link/to/${endPoint},${endLat},${endLng}`;
+  window.open(kakaoAppUrl, "_blank");
+
+  // APP이 설치되어 있지 않으면 웹으로 리다이렉트트
+  setTimeout(() => {
+    if (!document.hidden) {
+      window.open(kakaoMapUrl, "_blank");
+    }
+  }, 1000);
 };

--- a/src/features/mapView/utils/naverMap.ts
+++ b/src/features/mapView/utils/naverMap.ts
@@ -3,10 +3,10 @@ import { OpenMapProps } from "../model";
 interface OpenNaverMapProps extends OpenMapProps {
   startPoint: string;
   startLat: number;
-  startLog: number;
+  startLng: number;
 }
 
-export const openNaverMap = ({ startPoint, startLat, startLog, endPoint, endLat, endLog }: OpenNaverMapProps) => {
-  const naverMapUrl = `https://map.naver.com/index.nhn?slng=${startLog}&slat=${startLat}&stext=${startPoint}&elng=${endLog}&elat=${endLat}&etext=${endPoint}&menu=route`;
+export const openNaverMap = ({ startPoint, startLat, startLng, endPoint, endLat, endLng }: OpenNaverMapProps) => {
+  const naverMapUrl = `https://map.naver.com/index.nhn?slng=${startLng}&slat=${startLat}&stext=${startPoint}&elng=${endLng}&elat=${endLat}&etext=${endPoint}&menu=route`;
   window.open(naverMapUrl, "_blank");
 };

--- a/src/features/mapView/utils/tMap.ts
+++ b/src/features/mapView/utils/tMap.ts
@@ -1,7 +1,7 @@
 import { OpenMapProps } from "../model";
 
-export const openTMAP = ({ endPoint, endLat, endLog }: OpenMapProps) => {
-  const tMapUrl = `tmap://route?goalname=${endPoint}&goalx=${endLog}&goaly=${endLat}`;
+export const openTMAP = ({ endPoint, endLat, endLng }: OpenMapProps) => {
+  const tMapUrl = `tmap://route?goalname=${endPoint}&goalx=${endLng}&goaly=${endLat}`;
   const appStoreUrl = "https://apps.apple.com/kr/app/t-map/id431589174";
 
   window.open(tMapUrl, "_blank");


### PR DESCRIPTION
# 🛠 구현 사항

- 지하철 노선명에 따른 컴포넌트 렌더링 문제 해결

# ❓ 질문

- 질문 작성

# 📸 화면 캡처

- 지하철 노선명에 따른 컴포넌트 렌더링 문제 해결 (지하철 노선명이 수도권 9호선(급행) 과 같은 경우를 처리하기 위함입니다.)
- config const명도 파일명과 통일했습니다!

# 💬 리뷰 요구사항
