### PR TITLE
[feat] : 서비스 약관 페이지 UI 구현

### DIFF
--- a/src/app/routes/routes.tsx
+++ b/src/app/routes/routes.tsx
@@ -9,6 +9,8 @@ import ReviewPage from "@/pages/ReviewPage";
 import VisitedPage from "@/pages/VisitedPage";
 import MyPage from "@/pages/MyPage";
 import NotVisitedPage from "@/pages/NotVisitedPage";
+import PolicyPage from "@/pages/PolicyPage";
+import MarketingPage from "@/pages/MarketingPage";
 
 export const router = createBrowserRouter([
   { path: "/", element: <MainPage /> },
@@ -21,4 +23,6 @@ export const router = createBrowserRouter([
   { path: "/review/:id", element: <ReviewPage /> },
   { path: "/visited/:id", element: <VisitedPage /> },
   { path: "/notvisited/:id", element: <NotVisitedPage /> },
+  { path: "/policy", element: <PolicyPage /> },
+  { path: "/marketing", element: <MarketingPage /> },
 ]);

--- a/src/features/history/ui/CheckBox.tsx
+++ b/src/features/history/ui/CheckBox.tsx
@@ -6,16 +6,17 @@ interface CheckBoxProps {
   label: string;
   isChecked: boolean;
   onToggle: () => void;
+  onClick: () => void;
 }
 
-export const CheckBox = ({ label, isChecked, onToggle }: CheckBoxProps) => {
+export const CheckBox = ({ label, isChecked, onToggle, onClick }: CheckBoxProps) => {
   return (
     <div className="flex justify-between">
       <button className="flex gap-2 items-center" onClick={onToggle}>
         <img src={isChecked ? CheckActive : Check} alt="check" className="w-5 h-5" />
         <p className="text-md font-medium text-gray-60">{label}</p>
       </button>
-      <button>
+      <button onClick={onClick}>
         <img src={Arrow} alt="arrow" className="w-4 h-4" />
       </button>
     </div>

--- a/src/features/history/ui/PolicyBottomSheet.tsx
+++ b/src/features/history/ui/PolicyBottomSheet.tsx
@@ -4,12 +4,14 @@ import Button from "@/shared/ui/Button";
 import { useState } from "react";
 import { CheckBox } from "./CheckBox";
 import { useStoreAgreement } from "../hooks";
+import { useNavigate } from "react-router-dom";
 
 interface PolicyBottomSheetProps {
   onClose: () => void;
 }
 
 export const PolicyBottomSheet = ({ onClose }: PolicyBottomSheetProps) => {
+  const navigate = useNavigate();
   const { mutate } = useStoreAgreement();
   const [agreements, setAgreements] = useState({
     personalInfo: false,
@@ -52,11 +54,13 @@ export const PolicyBottomSheet = ({ onClose }: PolicyBottomSheetProps) => {
                 label="이용약관 및 개인정보처리방침(필수)"
                 isChecked={agreements.personalInfo}
                 onToggle={() => handleToggle("personalInfo")}
+                onClick={() => navigate("/policy")}
               />
               <CheckBox
                 label="마케팅 수신 동의(선택)"
                 isChecked={agreements.marketing}
                 onToggle={() => handleToggle("marketing")}
+                onClick={() => navigate("/marketing")}
               />
             </div>
           </div>

--- a/src/features/my/ui/Menu.tsx
+++ b/src/features/my/ui/Menu.tsx
@@ -1,30 +1,33 @@
 import Arrow from "@/assets/icon/rightArrow.svg";
-
-const menuItems = [
-  {
-    label: "이용약관 및 개인정보처리방침",
-    hasArrow: true,
-    onClick: () => {
-      console.log("이용약관 클릭");
-    },
-  },
-  {
-    label: "의견 남기기",
-    hasArrow: true,
-    onClick: () => {
-      console.log("의견 남기기 클릭");
-    },
-  },
-  {
-    label: "탈퇴하기",
-    hasArrow: false,
-    onClick: () => {
-      console.log("탈퇴하기 클릭");
-    },
-  },
-];
+import { useNavigate } from "react-router-dom";
 
 export const Menu = () => {
+  const navigate = useNavigate();
+
+  const menuItems = [
+    {
+      label: "이용약관 및 개인정보처리방침",
+      hasArrow: true,
+      onClick: () => {
+        navigate("/policy");
+      },
+    },
+    {
+      label: "의견 남기기",
+      hasArrow: true,
+      onClick: () => {
+        console.log("의견 남기기 클릭");
+      },
+    },
+    {
+      label: "탈퇴하기",
+      hasArrow: false,
+      onClick: () => {
+        console.log("탈퇴하기 클릭");
+      },
+    },
+  ];
+
   return (
     <div className="flex flex-col py-3 px-5">
       {menuItems.map((item, idx) => (

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 const HistoryPage = () => {
   const { data, isLoading, isError } = useUserInfo();
   const { userEvents, isEventsLoading, isEventsError } = useUserEvents();
-  const [isPolicy, setIsPolicy] = useState(false);
+  const [isPolicy, setIsPolicy] = useState(true);
   const profileImageUrl = useUserStore(state => state.profileImageUrl);
   const length = 1; // 임시 ui 구현을 위한 작업!
   const navigate = useNavigate();
@@ -32,7 +32,7 @@ const HistoryPage = () => {
     });
 
     // 개인정보 동의 여부 설정
-    setIsPolicy(!data.personalInfoAgreement);
+    //setIsPolicy(!data.personalInfoAgreement);
 
     // localStorage에서 이벤트 아이디를 가져와 리디렉션 처리
     const eventIdFromStorage = localStorage.getItem("shared_link_access");

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 const HistoryPage = () => {
   const { data, isLoading, isError } = useUserInfo();
   const { userEvents, isEventsLoading, isEventsError } = useUserEvents();
-  const [isPolicy, setIsPolicy] = useState(true);
+  const [isPolicy, setIsPolicy] = useState(false);
   const profileImageUrl = useUserStore(state => state.profileImageUrl);
   const length = 1; // 임시 ui 구현을 위한 작업!
   const navigate = useNavigate();
@@ -32,7 +32,7 @@ const HistoryPage = () => {
     });
 
     // 개인정보 동의 여부 설정
-    //setIsPolicy(!data.personalInfoAgreement);
+    setIsPolicy(!data.personalInfoAgreement);
 
     // localStorage에서 이벤트 아이디를 가져와 리디렉션 처리
     const eventIdFromStorage = localStorage.getItem("shared_link_access");

--- a/src/pages/MarketingPage.tsx
+++ b/src/pages/MarketingPage.tsx
@@ -1,0 +1,72 @@
+import { CloseHeader } from "@/widgets/headers";
+import { useNavigate } from "react-router-dom";
+
+const marketingContents = [
+  {
+    title: "1. 수신 항목 및 목적",
+    contents: [
+      "SPOT에서 제공하는 이벤트, 프로모션, 할인정보 등 마케팅 및 광고성 정보 제공",
+      "새로운 서비스 및 기능 업데이트 안내",
+      "이용자 맞춤형 광고 및 혜택 제공",
+    ],
+  },
+  {
+    title: "2. 전송 수단",
+    contents: ["서비스 내 알림(Push), SMS(문자메시지), 이메일, 전화 등"],
+  },
+  {
+    title: "3. 수신 동의 철회 방법",
+    contents: [
+      "사용자는 언제든지 별도 문의를 통해 마케팅 정보 수신 동의를 철회할 수 있습니다.",
+      "철회 시, 이후 해당 정보를 수신하지 않게 됩니다.",
+    ],
+  },
+  {
+    title: "4. 보유 및 이용 기간",
+    contents: ["동의일로부터 수신 철회 또는 회원 탈퇴 시까지"],
+  },
+  {
+    title: "5. 기타 안내",
+    contents: [
+      "본 동의는 마케팅 정보 수신을 위한 것으로, 서비스 이용을 위한 필수 동의사항이 아닙니다.",
+      "동의하지 않더라도 SPOT 기본 서비스 이용에 제한은 없습니다.",
+      "※ 관련 법령: 「정보통신망 이용촉진 및 정보보호 등에 관한 법률」 제50조, 제66조 등",
+    ],
+  },
+];
+
+const MarketingPage = () => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div className="flex flex-col h-screen-dvh" onClick={handleClick}>
+      <CloseHeader title="마케팅 수신 동의" />
+      <div className="flex-1 p-5 text-md text-gray-60 overflow-y-scroll scrollbar-hidden min-h-0">
+        <h2 className="text-gray-80 font-semibold">마케팅 정보 수신에 대한 동의 안내</h2>
+        <p>
+          SPOT은 사용자의 편의를 위해 다양한 혜택, 이벤트, 신제품 출시 및 맞춤형 서비스 안내 등 마케팅 정보를 아래와
+          같은 방법으로 전달할 수 있습니다.
+        </p>
+        <hr className="my-3" />
+
+        {marketingContents.map((section, idx) => (
+          <div key={idx}>
+            <h3 className="text-gray-80 font-semibold">{section.title}</h3>
+            <ul>
+              {section.contents.map((text, i) => (
+                <p key={i}>{text}</p>
+              ))}
+            </ul>
+            <hr className="my-3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MarketingPage;

--- a/src/pages/MarketingPage.tsx
+++ b/src/pages/MarketingPage.tsx
@@ -43,8 +43,8 @@ const MarketingPage = () => {
   };
 
   return (
-    <div className="flex flex-col h-screen-dvh" onClick={handleClick}>
-      <CloseHeader title="마케팅 수신 동의" />
+    <div className="flex flex-col h-screen-dvh">
+      <CloseHeader title="마케팅 수신 동의" onClick={handleClick} />
       <div className="flex-1 p-5 text-md text-gray-60 overflow-y-scroll scrollbar-hidden min-h-0">
         <h2 className="text-gray-80 font-semibold">마케팅 정보 수신에 대한 동의 안내</h2>
         <p>
@@ -56,11 +56,11 @@ const MarketingPage = () => {
         {marketingContents.map((section, idx) => (
           <div key={idx}>
             <h3 className="text-gray-80 font-semibold">{section.title}</h3>
-            <ul>
+            <>
               {section.contents.map((text, i) => (
                 <p key={i}>{text}</p>
               ))}
-            </ul>
+            </>
             <hr className="my-3" />
           </div>
         ))}

--- a/src/pages/PolicyPage.tsx
+++ b/src/pages/PolicyPage.tsx
@@ -1,0 +1,188 @@
+import { CloseHeader } from "@/widgets/headers";
+import { useNavigate } from "react-router-dom";
+
+const policySections = [
+  {
+    title: "1. 서비스 이용 시 유의사항",
+    contents: [
+      {
+        type: "p",
+        text: "사용자는 다음 각 호에 해당하는 행위를 해서는 안 되며, 위반 시 회사는 서비스 이용 제한, 강제탈퇴 등 필요한 조치를 취할 수 있습니다.",
+      },
+      { type: "li", text: "1. 회사가 명시하지 않은 방식으로 서비스에 접근하거나 방해하는 행위" },
+      { type: "li", text: "2. 타인의 개인정보를 무단 수집, 이용하거나 제3자에게 제공하는 행위" },
+      { type: "li", text: "3. SPOT 서비스를 영리, 홍보 등 부정한 목적에 사용하는 행위" },
+      { type: "li", text: "4. 법령이나 공공질서에 위배되는 정보를 게시 또는 전송하는 행위" },
+      { type: "li", text: "5. 서비스 또는 소프트웨어의 무단 복제, 수정, 배포, 판매, 대여, 역설계 등의 행위" },
+      { type: "li", text: "6. 관련 법령 및 본 약관 또는 운영정책을 위반하는 행위" },
+    ],
+  },
+  {
+    title: "2. 개인정보 보호",
+    contents: [
+      {
+        type: "p",
+        text: `회사는 서비스 제공을 위한 최소한의 개인정보만 수집하며, 사용자의 동의 범위 내에서만 이용합니다. 보다 자세한
+          내용은 [SPOT 개인정보처리방침]을 확인해 주세요.`,
+      },
+    ],
+  },
+  {
+    title: "3. 공지 및 알림",
+    contents: [
+      {
+        type: "p",
+        text: `회사는 서비스 운영과 관련된 중요사항 또는 마케팅 정보를 앱 내 알림, 문자메시지, 이메일 등으로 안내할 수 있습니다. 사용자는 언제든지 수신을 거부할 수 있으며, 수신 거부 시 회사는 해당 정보를 더 이상 발송하지 않습니다. 다만, 법령상 의무 고지는 수신 거부 대상에서 제외됩니다.`,
+      },
+    ],
+  },
+  {
+    title: "4. 위치기반서비스 관련 안내",
+    contents: [
+      {
+        type: "p",
+        text: "SPOT은 현재 위치를 기반으로 중간 지점을 탐색하여 추천하는 서비스를 제공합니다. 본 서비스는 단말기의 위치정보를 수집하는 위치정보사업자를 통해 정보를 전달받으며, 사용자 동의 하에 무료로 제공됩니다.",
+      },
+      {
+        type: "li",
+        text: "14세 미만 사용자는 법정대리인의 동의가 반드시 필요하며, 미동의 시 위치기반서비스 제공이 제한됩니다.",
+      },
+      {
+        type: "li",
+        text: "사용자는 위치정보의 이용 및 제공에 대해 전부 또는 일부 철회할 수 있으며, 철회 시 관련 정보는 즉시 파기됩니다.",
+      },
+      {
+        type: "li",
+        text: "8세 이하 아동, 금치산자, 중증 정신장애인의 경우 보호의무자의 서면 동의가 있으면 본인의 동의가 있는 것으로 간주합니다.",
+      },
+      { type: "li", text: "위치정보 분쟁 발생 시, 개인정보분쟁조정위원회에 조정을 신청할 수 있습니다." },
+    ],
+  },
+  {
+    title: "5. 유료서비스 안내",
+    contents: [
+      {
+        type: "p",
+        text: `SPOT은 사용자의 편의를 위한 일부 기능을 유료로 제공할 수 있으며, 세부 조건은 별도의 [유료서비스 이용약관]에 따릅니다.`,
+      },
+    ],
+  },
+  {
+    title: "6. 서비스의 중단",
+    contents: [
+      {
+        type: "p",
+        text: `정기 또는 임시 점검, 기술적 사유 등으로 인해 서비스 제공이 일시 중단될 수 있습니다. 이 경우 회사는 서비스 화면 또는 별도 통지 수단을 통해 안내합니다.`,
+      },
+    ],
+  },
+  {
+    title: "6. 서비스의 중단",
+    contents: [
+      {
+        type: "p",
+        text: `정기 또는 임시 점검, 기술적 사유 등으로 인해 서비스 제공이 일시 중단될 수 있습니다. 이 경우 회사는 서비스 화면 또는 별도 통지 수단을 통해 안내합니다.`,
+      },
+    ],
+  },
+  {
+    title: "7. 이용계약 해지",
+    contents: [
+      {
+        type: "p",
+        text: `사용자는 언제든지 서비스 내 설정 메뉴를 통해 탈퇴할 수 있으며, 회사는 법령에 따라 즉시 처리합니다. 단, 거래가 진행 중이거나 분쟁이 있는 경우 탈퇴가 일시 제한될 수 있으며, 이용자가 작성한 게시물은 삭제되지 않을 수 있습니다.`,
+      },
+    ],
+  },
+  {
+    title: "8. 약관의 변경",
+    contents: [
+      {
+        type: "p",
+        text: `회사는 법률 개정 또는 서비스 변경 사항을 반영하여 본 약관을 수정할 수 있으며, 변경 내용은 서비스 화면에 사전 공지됩니다.`,
+      },
+      {
+        type: "li",
+        text: `통상 변경: 게시 후 7일 경과 시 효력 발생`,
+      },
+      {
+        type: "li",
+        text: `사용자 불리 변경: 게시 후 30일 경과 시 효력 발생`,
+      },
+      {
+        type: "p",
+        text: `변경된 약관에 동의하지 않을 경우, 사용자는 서비스 이용을 중단할 수 있으며, 계속 사용할 경우 동의한 것으로 간주됩니다.`,
+      },
+    ],
+  },
+  {
+    title: "9. 사용자 의견",
+    contents: [
+      {
+        type: "p",
+        text: `사용자는 언제든지 서비스 내 문의하기 기능 등을 통해 의견을 제출할 수 있으며, 회사는 이를 적극 반영하기 위해 노력합니다.`,
+      },
+    ],
+  },
+  {
+    title: "10. 기타 사항",
+    contents: [
+      {
+        type: "p",
+        text: `본 약관은 대한민국 법률을 따릅니다.`,
+      },
+      {
+        type: "p",
+        text: `일부 조항이 무효가 되더라도 다른 조항의 효력에는 영향을 미치지 않습니다.`,
+      },
+    ],
+  },
+];
+
+const PolicyPage = () => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div className="flex flex-col h-screen-dvh">
+      <CloseHeader title="이용약관 및 개인정보처리방침" onClick={handleClick} />
+      <div className="flex-1 p-5 text-md text-gray-60 overflow-y-scroll scrollbar-hidden min-h-0">
+        <h2 className="text-gray-80 font-semibold">SPOT 서비스 이용약관</h2>
+        <p>
+          감사합니다. 본 약관은 모임의 중간지점을 편리하게 찾아주는 위치기반 서비스인 "SPOT"(이하 "회사")의 이용과
+          관련된 사용자 권리, 의무 및 책임사항을 규정합니다.
+        </p>
+        <hr className="my-3" />
+
+        {policySections.map((section, idx) => (
+          <div key={idx}>
+            <h3 className="text-gray-80 font-semibold">{section.title}</h3>
+
+            {/* 순서 유지한 채 p/li 모두 map으로 순회 */}
+            <ul className="list-disc pl-5 space-y-1">
+              {section.contents.map((c, i) =>
+                c.type === "li" ? (
+                  <li key={i}>{c.text}</li>
+                ) : (
+                  <li key={i} className="list-none">
+                    <p>{c.text}</p>
+                  </li>
+                )
+              )}
+            </ul>
+
+            <hr className="my-3" />
+          </div>
+        ))}
+
+        <li>공고일자: 2025년 5월 31일</li>
+        <li>시행일자: 2025년 5월 31일</li>
+      </div>
+    </div>
+  );
+};
+
+export default PolicyPage;

--- a/src/widgets/headers/ui/CloseHeader.tsx
+++ b/src/widgets/headers/ui/CloseHeader.tsx
@@ -3,10 +3,11 @@ import Close from "@/assets/icon/close.svg";
 
 interface CloseHeaderProps {
   url?: string;
+  title?: string;
   onClick?: () => void;
 }
 
-export const CloseHeader = ({ url, onClick }: CloseHeaderProps) => {
+export const CloseHeader = ({ url, title, onClick }: CloseHeaderProps) => {
   const navigate = useNavigate();
   const handleClick = () => {
     if (onClick) {
@@ -17,8 +18,9 @@ export const CloseHeader = ({ url, onClick }: CloseHeaderProps) => {
   };
 
   return (
-    <header className="w-full px-5 py-3 flex justify-end">
-      <button onClick={handleClick}>
+    <header className="relative w-full px-5 py-3 flex justify-center items-center">
+      {title && <span className="text-md font-semibold text-gray-90">{title}</span>}
+      <button onClick={handleClick} className="absolute top-3 right-5">
         <img src={Close} alt="close" className="w-6 h-6" />
       </button>
     </header>


### PR DESCRIPTION
# 🛠 구현 사항

- 서비스 약관 페이지 UI 구현

# ❓ 질문

- X

# 📸 화면 캡처
![image](https://github.com/user-attachments/assets/e913028a-842d-4bed-b2de-d815fd99c0e8)
![image](https://github.com/user-attachments/assets/8602935e-e985-4d4a-8498-c9a6e9b214f4)
![image](https://github.com/user-attachments/assets/bf42c8a0-fb33-491e-a7f1-c4b4c9dd17d1)
![image](https://github.com/user-attachments/assets/22220082-8c47-4642-8f8f-94f2a2faf90f)

# 💬 리뷰 요구사항
시맨틱 태그와 중복되는 ui를 최대한 줄이고자 했습니다. 또한, 페이지의 특별한 기능이 없어서 따로 폴더를 만들지 않았습니다. 