### PR TITLE
[refactor] : service, hooks 로직 분리 및 리팩토링

### DIFF
--- a/src/features/detail/service/api.ts
+++ b/src/features/detail/service/api.ts
@@ -1,30 +1,28 @@
 import api from "@/shared/api/api";
 
-export const getPlaceInfo = async ({ placeId, eventId }: { placeId: string; eventId: string }) => {
-  try {
-    const response = await api.get(`places/${placeId}`, { params: { placeId, eventId } });
-    if (response.data.result === "SUCCESS") {
-      return response.data.data;
-    } else {
-      console.error("장소 정보 조회 실패 : ", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+interface PlaceInfoProps {
+  placeId: string;
+  eventId: string;
+}
+
+export const getPlaceInfo = async ({ placeId, eventId }: PlaceInfoProps) => {
+  const response = await api.get(`/places/${placeId}`, {
+    params: { placeId, eventId },
+  });
+
+  if (response.data.result === "SUCCESS") {
+    return response.data.data;
   }
+
+  throw new Error(response.data.error?.message || "모임 장소 조회 실패");
 };
 
-export const postPlaceInfo = async ({ placeId, eventId }: { placeId: string; eventId: string }) => {
-  try {
-    const response = await api.post(`/places/${placeId}`, null, { params: { placeId, eventId } });
+export const postPlaceInfo = async ({ placeId, eventId }: PlaceInfoProps) => {
+  const response = await api.post(`/places/${placeId}`, null, { params: { placeId, eventId } });
 
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error("모임 장소 확정 및 변경 실패 : ", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+  if (response.data.result === "SUCCESS") {
+    return true;
   }
+
+  throw new Error(response.data.error?.message || "모임 장소 확정 실패");
 };

--- a/src/features/find/service/api.ts
+++ b/src/features/find/service/api.ts
@@ -2,21 +2,21 @@ import api from "@/shared/api/api";
 import { FormattedData } from "../model";
 
 export const createEvent = async (payload: FormattedData) => {
-  try {
-    const response = await api.post("/events", payload);
-    return response.data;
-  } catch (error) {
-    console.error("모임 생성 실패:", error);
-    throw error;
+  const response = await api.post("/events", payload);
+
+  if (response.data.result !== "SUCCESS") {
+    throw new Error(response.data.error?.message || "모임 생성 실패");
   }
+
+  return response.data;
 };
 
 export const addMember = async (payload: FormattedData, eventId: string) => {
-  try {
-    const response = await api.post(`/events/${eventId}/start-points`, payload);
-    return response.data;
-  } catch (error) {
-    console.log("멤버 추가 실패", error);
-    throw error;
+  const response = await api.post(`/events/${eventId}/start-points`, payload);
+
+  if (response.data.result !== "SUCCESS") {
+    throw new Error(response.data.error?.message || "멤버 추가 실패");
   }
+
+  return response.data;
 };

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,16 +1,10 @@
 import api from "@/shared/api/api";
 
 export const getUserInfo = async () => {
-  try {
-    const response = await api.get("/users");
-    if (response.data.result === "SUCCESS") {
-      return response.data.data;
-    } else {
-      console.error("유저 정보 조회 실패 : ", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+  const response = await api.get("/users");
+
+  if (response.data.result === "SUCCESS") {
+    return response.data.data;
   }
 };
 
@@ -21,33 +15,24 @@ export const storeUserAgreement = async ({
   isPersonalInfoAgreement: boolean;
   isMarketingAgreement: boolean;
 }) => {
-  try {
-    const response = await api.post("/users/agreement", {
-      isPersonalInfoAgreement,
-      isMarketingAgreement,
-    });
+  const response = await api.post("/users/agreement", {
+    isPersonalInfoAgreement,
+    isMarketingAgreement,
+  });
 
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error("약관 정보 동의 실패 : ", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+  if (response.data.result === "SUCCESS") {
+    return true;
   }
+
+  throw new Error(response.data.error?.message || "약관 동의 저장장 실패");
 };
 
 export const getUserEvents = async () => {
-  try {
-    const response = await api.get("/users/events");
-    if (response.data.result === "SUCCESS") {
-      return response.data.data;
-    } else {
-      console.error("유저 모임 조회 실패 : ", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+  const response = await api.get("/users/events");
+
+  if (response.data.result === "SUCCESS") {
+    return response.data.data;
   }
+
+  throw new Error(response.data.error?.message || "유저 정보 조회 실패");
 };

--- a/src/features/mapView/service/api.ts
+++ b/src/features/mapView/service/api.ts
@@ -2,42 +2,35 @@ import api from "@/shared/api/api";
 import { GetEventRouteResponse } from "@/shared/model";
 
 export const getEventInfo = async (eventId: string, startPointId?: string) => {
-  try {
-    const response = await api.get<{
-      result: string;
-      data: GetEventRouteResponse;
-      error?: {
-        code: string;
-        message: string;
-      };
-    }>(`/events/${eventId}`, {
-      params: startPointId ? { startPointId } : {},
-    });
+  const response = await api.get<{
+    result: string;
+    data: GetEventRouteResponse;
+    error?: {
+      code: string;
+      message: string;
+    };
+  }>(`/events/${eventId}`, {
+    params: startPointId ? { startPointId } : {},
+  });
 
+  if (response.data.result === "SUCCESS") {
     return response.data.data;
-  } catch (error) {
-    console.error("모임 경로 조회 실패:", error);
-    throw error;
   }
+
+  throw new Error(response.data.error?.message || "모임 경로 조회 실패");
 };
 
 export const patchEvent = async (eventId: string, startPointId: string, isTransit: boolean) => {
-  try {
-    const response = await api.patch(`/events/${eventId}`, null, {
-      params: {
-        startPointId,
-        isTransit,
-      },
-    });
+  const response = await api.patch(`/events/${eventId}`, null, {
+    params: {
+      startPointId,
+      isTransit,
+    },
+  });
 
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error(":", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("대중교통 변경 실패:", error);
-    throw error;
+  if (response.data.result === "SUCCESS") {
+    return true;
   }
+
+  throw new Error(response.data.error?.message || "대중교통 변경 실패");
 };

--- a/src/features/my/service/api.ts
+++ b/src/features/my/service/api.ts
@@ -1,15 +1,11 @@
 import api from "@/shared/api/api";
 
 export const logout = async () => {
-  try {
-    const response = await api.post("/auth/logout");
-    if (response.data.result === "SUCCESS") {
-      return true;
-    } else {
-      console.error("서버 에러 발생", response.data.error.message);
-      throw new Error(response.data.error.message);
-    }
-  } catch (error) {
-    console.error("서버 에러 : ", error);
+  const response = await api.post("/auth/logout");
+
+  if (response.data.result === "SUCCESS") {
+    return true;
   }
+
+  throw new Error(response.data.error?.message || "로그아웃 실패");
 };

--- a/src/features/place/service/api.ts
+++ b/src/features/place/service/api.ts
@@ -5,5 +5,10 @@ export const getRecommendedPlaces = async (eventId: string) => {
   const response = await api.get<PlaceList>("/places", {
     params: { eventId },
   });
-  return response.data;
+
+  if (response.data.result === "SUCCESS") {
+    return response.data;
+  }
+
+  throw new Error(response.data.error?.message || "추천 장소 조회 실패");
 };


### PR DESCRIPTION
# 🛠 구현 사항

- [x] service, hooks 로직 분리 및 리팩토링

# ❓ 질문

- X

# 📸 화면 캡처

# 💬 리뷰 요구사항
- 현재 코드에서는 service와 hooks 부분이 명확하지 않으며 에러 핸들링이 중복으로 처리되고 있다고 생각하였습니다. 따라서, 책임을 더욱 명확하게 하고자 service에서 api를 try-catch문으로 감싸는 방식을 제거하였습니다. 
- react-query에서 onSuccess, onError가 의도한 동작대로 잘 동작하기 위해 response.data.result가 SUCCESS인 경우에만 값을 반환하고 그 외에는 throw를 통해 명시적으로 예외를 발생시키도록 처리하였습니다.
- 이 부분 관련하여 많은 피드백 부탁드립니다! 