### PR TITLE
[feat] : guestId로 교체

### DIFF
--- a/src/features/find/hooks/useCreateStartPoint.ts
+++ b/src/features/find/hooks/useCreateStartPoint.ts
@@ -13,7 +13,6 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
     onSuccess: response => {
       const { eventId, guestId } = response.data;
 
-      // setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
       if (!getCookie("guestId")) {
         setCookie("guestId", guestId, { path: "/", maxAge: 86400 });
       }

--- a/src/features/find/hooks/useCreateStartPoint.ts
+++ b/src/features/find/hooks/useCreateStartPoint.ts
@@ -11,10 +11,12 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
   const { mutate: createEventMutate } = useMutation({
     mutationFn: createEvent,
     onSuccess: response => {
-      const { eventId, startPointId } = response.data;
+      const { eventId, guestId } = response.data;
 
-      setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
-      setCookie("startPointId", startPointId, { path: "/", maxAge: 86400 });
+      // setCookie("eventId", eventId, { path: "/", maxAge: 86400 });
+      if (!getCookie("guestId")) {
+        setCookie("guestId", guestId, { path: "/", maxAge: 86400 });
+      }
 
       // 페이지 이동
       navigate(`/mapview/${eventId}`);
@@ -28,8 +30,8 @@ export const useCreateStartPoint = (eventIdParam: string | null) => {
     mutationFn: ({ payload, eventId }: { payload: FormattedData; eventId: string }) => addMember(payload, eventId),
     onSuccess: response => {
       // 쿠키가 없을 때만 저장
-      if (!getCookie("startPointId")) {
-        setCookie("startPointId", response.data.startPointId, { path: "/", maxAge: 86400 });
+      if (!getCookie("guestId")) {
+        setCookie("guestId", response.data.guestId, { path: "/", maxAge: 86400 });
       }
       navigate(`/mapview/${eventIdParam}`);
     },

--- a/src/features/mapView/hooks/useEventInfo.ts
+++ b/src/features/mapView/hooks/useEventInfo.ts
@@ -2,16 +2,19 @@ import { useQuery } from "@tanstack/react-query";
 import { getCookie } from "@/shared/utils";
 import { getEventInfo } from "../service";
 import { useParams } from "react-router-dom";
+import { useUserStore } from "@/shared/stores";
 
 export const useEventRoutes = () => {
   const { id } = useParams();
-  const startPointId = getCookie("startPointId");
+  const guestId = getCookie("guestId");
+  const { nickname } = useUserStore();
 
   return useQuery({
-    queryKey: ["eventRoutes", id, startPointId],
+    queryKey: ["eventRoutes", id, guestId, nickname],
     queryFn: () => {
       if (!id) throw new Error("eventId가 없습니다.");
-      return getEventInfo(id, startPointId);
+      // 로그인한 사용자인 경우 guestId를 전달하지 않음
+      return getEventInfo(id, nickname ? undefined : guestId);
     },
     enabled: !!id, // eventId가 있을 때만 요청
     retry: false, // 자동 재시도 방지

--- a/src/features/mapView/service/api.ts
+++ b/src/features/mapView/service/api.ts
@@ -1,7 +1,7 @@
 import api from "@/shared/api/api";
 import { GetEventRouteResponse } from "@/shared/model";
 
-export const getEventInfo = async (eventId: string, startPointId?: string) => {
+export const getEventInfo = async (eventId: string, guestId?: string) => {
   const response = await api.get<{
     result: string;
     data: GetEventRouteResponse;
@@ -10,7 +10,7 @@ export const getEventInfo = async (eventId: string, startPointId?: string) => {
       message: string;
     };
   }>(`/events/${eventId}`, {
-    params: startPointId ? { startPointId } : {},
+    params: guestId ? { guestId } : {},
   });
 
   if (response.data.result === "SUCCESS") {

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -14,6 +14,7 @@ import LoadingSpinner from "@/shared/ui/LoadingSpinner";
 import { MapHeader } from "@/widgets/headers";
 import { AxiosError } from "axios";
 import { useEffect } from "react";
+import { setCookie } from "@/shared/utils";
 
 const MapViewPage = () => {
   const { data, isLoading, isError, error } = useEventRoutes();
@@ -26,6 +27,12 @@ const MapViewPage = () => {
   useEffect(() => {
     if (data) {
       setEventData(data);
+      // 현재 사용자의 routeResponse 찾기
+      const myRoute = data.routeResponse.find(route => route.isMe);
+      if (myRoute) {
+        // startPointId를 쿠키에 저장
+        setCookie("startPointId", myRoute.id, { path: "/", maxAge: 86400 });
+      }
     }
   }, [data, setEventData]);
 


### PR DESCRIPTION
# 🛠 구현 사항

- find : startPointId에서 guestId로 교체
- mp : isMe가 true인 경우에 startPointId를 쿠키에 저장(이벤트마다 갱신 가능)

# ❓ 질문
- 현재 guestId 쿠키의 유효 시간이 하루인데, 이걸 무제한으로 설정하는게 괜찮을지 고민입니다. 어떻게 생각하시나요?
- 링크를 타고 들어온 사용자의 경우 쿠키의 유효기간 하루가 지나면 다음날에는 isMe가 false로 와서 대중교통 전환을 못하게 됩니다. (guestId의 유지 기간을 고민해봐야 할 것 같아요)

# 📸 화면 캡처

# 💬 리뷰 요구사항
- find에서 이벤트 생성, 출발지 등록 시 startPointId에서 guestId로 교체하였습니다.
- 이미 guestId가 존재하는 경우에는 쿠키를 갱신하지 못하도록 하였습니다.
- 로그인을 한 사용자는 guestId를 포함하지 않도록 하였습니다.
- 대중교통 전환 요청을 위해 isMe가 true인 경우 사용자의 id를 뽑아 startPointId로 저장되도록 구현했습니다.