### PR TITLE
[feat] : HI 무한스크롤 적용 및 401 에러 처리

### DIFF
--- a/src/features/history/hooks/useUserEvents.ts
+++ b/src/features/history/hooks/useUserEvents.ts
@@ -1,17 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { getUserEvents } from "../service";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { UserEvents } from "../model";
+import { getUserEvents } from "../service";
 
 export const useUserEvents = () => {
-  const {
-    data: userEvents,
-    isLoading: isEventsLoading,
-    isError: isEventsError,
-  } = useQuery<UserEvents[]>({
+  return useInfiniteQuery<UserEvents>({
     queryKey: ["userEvents"],
-    queryFn: getUserEvents,
-    retry: 2, // 실패 시 최대 두 번 재시도
-    staleTime: 1000 * 60 * 5, // 5분 동안 데이터 캐시 유지
+    queryFn: ({ pageParam }) => getUserEvents({ pageParam: pageParam as string | undefined }),
+    getNextPageParam: lastPage => (lastPage.hasNextPage ? lastPage.lastEventId : undefined),
+    initialPageParam: undefined,
   });
-  return { userEvents, isEventsLoading, isEventsError };
 };

--- a/src/features/history/model/userEvents.type.ts
+++ b/src/features/history/model/userEvents.type.ts
@@ -1,9 +1,16 @@
-export interface UserEvents {
+export interface UserEventHistoryResponses {
   eventId: string;
   middlePointName: string;
   placeName: string;
   participatedPeopleCount: number;
   userProfileImageUrls: string[];
   eventMadeAgo: number;
+  eventHourAgo: number;
   isReviewed: boolean;
+}
+
+export interface UserEvents {
+  userEventHistoryResponses: UserEventHistoryResponses[];
+  hasNextPage: boolean;
+  lastEventId: string;
 }

--- a/src/features/history/service/api.ts
+++ b/src/features/history/service/api.ts
@@ -1,4 +1,5 @@
 import api from "@/shared/api/api";
+import { UserEvents } from "../model";
 
 export const getUserInfo = async () => {
   const response = await api.get("/users");
@@ -27,11 +28,13 @@ export const storeUserAgreement = async ({
   throw new Error(response.data.error?.message || "약관 동의 저장장 실패");
 };
 
-export const getUserEvents = async () => {
-  const response = await api.get("/users/events");
+export const getUserEvents = async ({ pageParam }: { pageParam?: string }) => {
+  const response = await api.get("/users/events", {
+    params: { lastViewedEventId: pageParam, size: 10 },
+  });
 
   if (response.data.result === "SUCCESS") {
-    return response.data.data;
+    return response.data.data as UserEvents;
   }
 
   throw new Error(response.data.error?.message || "유저 정보 조회 실패");

--- a/src/features/history/ui/GroupCard.tsx
+++ b/src/features/history/ui/GroupCard.tsx
@@ -2,7 +2,8 @@ import { useNavigate } from "react-router-dom";
 import { Chip } from "./Chip";
 import Pin from "@/assets/icon/pin.svg";
 import DefaultProfile from "@/assets/icon/default-profile.svg";
-import { UserEvents } from "../model";
+import { UserEventHistoryResponses } from "../model";
+import { formatDaysAgo } from "../utils";
 
 export const GroupCard = ({
   eventId,
@@ -11,8 +12,9 @@ export const GroupCard = ({
   participatedPeopleCount,
   userProfileImageUrls,
   eventMadeAgo,
+  eventHourAgo,
   isReviewed,
-}: UserEvents) => {
+}: UserEventHistoryResponses) => {
   const navigate = useNavigate();
 
   const maxToShow = 3;
@@ -25,6 +27,8 @@ export const GroupCard = ({
   const handleClick = () => {
     navigate(`/mapView/${eventId}`);
   };
+
+  const eventAgoText = eventMadeAgo === 0 ? `${eventHourAgo}시간 전` : formatDaysAgo(eventMadeAgo);
 
   return (
     <section className="flex flex-col px-5 pb-5 pt-4 gap-1 border-b border-b-gray-5">
@@ -62,7 +66,7 @@ export const GroupCard = ({
 
           <p className="text-gray-90">{participatedPeopleCount}명</p>
           <p className="font-semibold text-gray-40">·</p>
-          <p className="text-gray-40">{eventMadeAgo}일 전</p>
+          <p className="text-gray-40">{eventAgoText}</p>
         </div>
         {placeName && <Chip isComplete={isReviewed} id={eventId} />}
       </div>

--- a/src/features/history/utils/formatDaysAgo.ts
+++ b/src/features/history/utils/formatDaysAgo.ts
@@ -1,0 +1,19 @@
+export const formatDaysAgo = (day: number) => {
+  if (day < 7) {
+    return `${day}일 전`;
+  } else if (day < 14) {
+    return "1주일 전";
+  } else if (day < 28) {
+    return "2주 전";
+  } else if (day < 60) {
+    return "한 달 전";
+  } else if (day < 90) {
+    return "두 달 전";
+  } else if (day < 365) {
+    const months = Math.floor(day / 30);
+    return `${months}개월 전`;
+  } else {
+    const years = Math.floor(day / 365);
+    return `${years}년 전`;
+  }
+};

--- a/src/features/history/utils/index.ts
+++ b/src/features/history/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./formatDaysAgo";

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -9,4 +9,14 @@ const api = axios.create({
   withCredentials: true,
 });
 
+api.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response?.status === 401) {
+      window.location.href = "/";
+    }
+    return Promise.reject(err);
+  }
+);
+
 export default api;


### PR DESCRIPTION
# 🛠 구현 사항

- [x] 이벤트 생성 요일, 시간에 따른 문구 적용 완료
- [x] HI 페이지 무한스크롤 적용 완료
- [x] 401 에러 발생 시 interceptors로 / 페이지로 이동하도록 구현

# ❓ 질문

- HI 페이지 데이터 요청 수를 프론트 단에서 조절할 수 있는데 우선 10개로 잡아두었습니다. size가 몇 개가 적당할까요?

# 📸 화면 캡처
- 요일, 시간에 따른 텍스트 적용 완료! 
![image](https://github.com/user-attachments/assets/b9329232-700d-41e3-bf52-7ce1de642e27)

# 💬 리뷰 요구사항
1. 쿠키가 만료될 경우 현재는 리프레쉬토큰으로 액세스 토큰을 재발급 받는 구조가 아니라서 401 에러가 날 경우 hi 페이지에서 에러 문구가 뜨게 됩니다.(다른 페이지에서 에러가 발생했을 때도 마찬가지입니다!) 따라서, api에 interceptors 추가하여 401에러 발생 시 바로 / 로 이동하여 다시 로그인하게 유도했습니다. 