### PR TITLE
fix: find 2차 수정사항 반영

### DIFF
--- a/src/features/find/ui/EventNameStep.tsx
+++ b/src/features/find/ui/EventNameStep.tsx
@@ -157,7 +157,7 @@ export const EventNameStep = ({
     <div className="flex flex-col h-full">
       <div className="flex-1 px-4">
         <div className="flex flex-col gap-6">
-          <PlainHeader onBack={() => setCurrentStep(0)} isEdit={isEdit} />
+          <PlainHeader onBack={() => navigate(-1)} isEdit={isEdit} />
           <p className="text-gray-90 text-xxl font-bold">
             <span className="text-sub-sub">어떤 모임인가요?</span>
             <br />

--- a/src/features/find/ui/LocationStep.tsx
+++ b/src/features/find/ui/LocationStep.tsx
@@ -46,6 +46,8 @@ export const LocationStep = ({
   const startPointId = useEventStore(state => state.detailEventData?.id);
   const detailEventData = useEventStore(state => state.detailEventData);
   const email = useUserStore(state => state.email);
+  const nickname = useUserStore(state => state.nickname);
+  const isLoggedIn = nickname !== null && nickname !== "";
   const personalInfoAgreement = useUserStore(state => state.personalInfoAgreement);
   const setPersonalInfoAgreement = useUserStore(state => state.setPersonalInfoAgreement);
 
@@ -233,8 +235,11 @@ export const LocationStep = ({
               if (eventIdParam) {
                 // eventId가 있으면 메인 페이지로 이동
                 window.history.back();
+              } else if (isLoggedIn) {
+                // 로그인한 사용자: NameStep을 건너뛰었으므로 EventNameStep으로 이동
+                setCurrentStep(0);
               } else {
-                // 새 모임 생성이면 이전 스텝으로
+                // 비로그인 사용자: 이전 스텝(NameStep)으로 이동
                 setCurrentStep(1);
               }
             }}

--- a/src/features/find/ui/NameStep.tsx
+++ b/src/features/find/ui/NameStep.tsx
@@ -3,7 +3,7 @@ import { validateName } from "@/shared/utils";
 import Button from "@/shared/ui/Button";
 import { useEffect, useState } from "react";
 import { InputField } from "@/shared/ui";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { PlainHeader } from "@/widgets/headers";
 import { gtagEvent } from "@/shared/utils";
 import { useUserStore } from "@/shared/stores";
@@ -18,6 +18,8 @@ export const NameStep = ({ setCurrentStep, setName, name }: NameStepProps) => {
   const { value, error, handleChange, validateValue, isValid } = useValidation(name, validateName);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const eventIdParam = searchParams.get("eventId");
   const nickname = useUserStore(state => state.nickname);
   const isLoggedIn = nickname !== null && nickname !== "";
 
@@ -61,7 +63,15 @@ export const NameStep = ({ setCurrentStep, setName, name }: NameStepProps) => {
     <div className="flex flex-col h-full">
       <div className="flex-1 px-4">
         <div className="flex flex-col gap-6">
-          <PlainHeader onBack={() => navigate(-1)} />
+          <PlainHeader
+            onBack={() => {
+              if (eventIdParam) {
+                navigate(-1);
+              } else {
+                setCurrentStep(0);
+              }
+            }}
+          />
           <p className="text-gray-90 text-xxl font-bold">
             새로운 출발지 추가를 위해
             <br />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -84,6 +84,15 @@ const MainPage = () => {
       <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[600px] px-5 py-3 bg-[rgba(255,255,255,0.05)] backdrop-blur-md ">
         <Button onClick={handleClick}>중간장소 찾기</Button>
       </div>
+      <div className="fixed bottom-[100px] left-1/2 -translate-x-1/2 w-full max-w-[600px] px-5 flex overflow-visible pointer-events-auto">
+        <iframe
+          title="disquiet-badge"
+          frameBorder="0"
+          src="https://badge.disquiet.io/vote-badge?productUrlSlug=모이삼&mode=light"
+          className="w-[300px] h-[80px] overflow-visible ml-auto -mr-[100px]"
+          style={{ overflow: 'visible' }}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# 🛠 구현 사항

### 1. 로그인한 사용자를 위한 네비게이션 로직 개선
  - **LocationStep.tsx**: 위치 선택 후 올바른 단계로 이동하도록 로그인 상태 확인 로직 추가
    - 로그인한 사용자: NameStep을 건너뛰고 바로 EventNameStep으로 이동
    - 비로그인 사용자: 기존처럼 NameStep으로 이동
    - 기존 이벤트: 브라우저 히스토리를 사용하여 뒤로 이동

  - **NameStep.tsx**: 새로운 위치 생성과 이벤트 편집을 구분하는 뒤로가기 네비게이션 로직 개선
    - 기존 이벤트 편집 시: 브라우저 뒤로가기 네비게이션 사용
    - 새로운 위치 생성 시: 첫 번째 단계로 이동

  - **EventNameStep.tsx**: 뒤로가기 네비게이션을 상태 관리 대신 브라우저 히스토리 사용으로 변경

  ### 2. 사용자 참여 기능
  - **MainPage.tsx**: 커뮤니티 투표 및 참여를 위한 Disquiet 배지 iframe 추가
    - 페이지 하단에 라이트 테마로 배치
    - 모바일 화면을 위한 반응형 포지셔닝 적용

  ## 수정된 파일
  - `src/features/find/ui/EventNameStep.tsx` - 네비게이션 수정
  - `src/features/find/ui/LocationStep.tsx` - 로그인한 사용자 네비게이션 개선
  - `src/features/find/ui/NameStep.tsx` - 뒤로가기 네비게이션 로직 개선
  - `src/pages/MainPage.tsx` - Disquiet 배지 위젯 추가

# ❓ 질문

- 질문 작성

# 📸 화면 캡처

# 💬 리뷰 요구사항
